### PR TITLE
expand list of sequence names excluded from this check

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/variation/CompressedGenotypeRegion.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/CompressedGenotypeRegion.java
@@ -175,8 +175,9 @@ public class CompressedGenotypeRegion extends SingleDatabaseTestCase {
     while (rs.next()) {
       region_name = rs.getString(1);
       count_genotype = rs.getInt(2);
-			
-      if (count_genotype < MIN_GENOTYPE && !region_name.equals("MT")) {  
+
+      // exclude short sequences from this check
+      if (count_genotype < MIN_GENOTYPE && !region_name.equals("MT") && !region_name.matches(".*PATCH")  && !region_name.matches("HSCHR.*")) {  
 				count++;
         if (msg.equals("none")) {
           msg=region_name;


### PR DESCRIPTION
Small change to check on the number of 1KG genotypes per sequence - excludes patches from the check
