### PR TITLE
Remove references to read coverage

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/variation/EmptyVariationTables.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/EmptyVariationTables.java
@@ -71,7 +71,6 @@ public class EmptyVariationTables extends SingleDatabaseTestCase {
     String[] sampleTables           = { "population_genotype", "population_structure", "population_synonym", "individual_synonym",  };
     String[] setTables              = { "variation_set_structure" };
     String[] genotypeTables         = { "compressed_genotype_region", "compressed_genotype_var" };
-    String[] coverageTables         = { "read_coverage" };
     String[] strainTables           = { "strain_gtype_poly" };
     String[] regulatoryTables       = { "motif_feature_variation", "regulatory_feature_variation" };
     String[] citationTables         = { "publication", "variation_citation" };
@@ -85,14 +84,6 @@ public class EmptyVariationTables extends SingleDatabaseTestCase {
     if (species != Species.HOMO_SAPIENS) {
       tables = remove(tables, humanOnlyTables);
       tables = remove(tables, setTables);
-    }
-
-    
-    
-    // only these species have coverage data
-
-    if (species != Species.RATTUS_NORVEGICUS && species != Species.MUS_MUSCULUS && species != Species.PONGO_ABELII && species != Species.HOMO_SAPIENS) {
-      tables = remove(tables, coverageTables);
     }
 
     // only these species have structural variation data

--- a/src/org/ensembl/healthcheck/testcase/variation/ForeignKeyCoreId.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ForeignKeyCoreId.java
@@ -112,11 +112,6 @@ public class ForeignKeyCoreId extends MultiDatabaseTestCase {
 						"seq_region_id IS NOT NULL");
 
 				result &= checkForOrphansWithConstraint(con, dbrvar.getName()
-						+ ".read_coverage", "seq_region_id", dbrcore.getName()
-						+ ".seq_region", "seq_region_id",
-						"seq_region_id IS NOT NULL");
-
-				result &= checkForOrphansWithConstraint(con, dbrvar.getName()
 						+ ".structural_variation_feature", "seq_region_id",
 						dbrcore.getName() + ".seq_region", "seq_region_id",
 						"seq_region_id IS NOT NULL");

--- a/src/org/ensembl/healthcheck/testcase/variation/Meta.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/Meta.java
@@ -71,43 +71,6 @@ public class Meta extends SingleDatabaseTestCase {
 					"population", "population_id", "meta_key = '" + metaKey + "'");
 
 		}
-		if (dbre.getSpecies() == Species.MUS_MUSCULUS
-				|| dbre.getSpecies() == Species.RATTUS_NORVEGICUS
-				|| dbre.getSpecies() == Species.HOMO_SAPIENS) {
-			// find out if the entries in the Meta point to the strain
-			// information
-			// String[] metaKeys =
-			// {"read_coverage.coverage_level","individual.default_strain","source.default_source"};
-			// String[] metaKeys =
-			// {"read_coverage.coverage_level","individual.default_strain","individual.display_strain","individual.reference_strain"};
-			String[] metaKeys = { "read_coverage.coverage_level" };
-			for (int i = 0; i < metaKeys.length; i++) {
-				metaKey = metaKeys[i];
-
-				result &= checkKeysPresent(con, metaKey);
-				if (metaKey == "read_coverage.coverage_level") {
-					result &= checkForOrphansWithConstraint(con, "meta",
-							"meta_value", "read_coverage", "level",
-							"meta_key = '" + metaKey + "'");
-				} else if ((metaKey == "individual.default_strain")
-						|| (metaKey == "individual.display_strain")) {
-					result &= checkForOrphansWithConstraint(con, "meta",
-							"meta_value", "individual",
-							"name COLLATE latin1_general_cs", "meta_key = '"
-									+ metaKey + "'");
-				} else if (metaKey == "individual.reference_strain") {
-					result &= checkKeysPresent(con, metaKey);
-
-				}
-				/*
-				 * else if (metaKey == "source.default_source"){ result &=
-				 * checkForOrphansWithConstraint
-				 * (con,"meta","meta_value","source","name","meta_key = '" +
-				 * metaKey + "'"); }
-				 */
-
-			}
-		}
 		if (dbre.getSpecies() == Species.CANIS_FAMILIARIS) {
 			// find out if the entries in the Meta point to the strain
 			// information

--- a/src/org/ensembl/healthcheck/testcase/variation/Meta_coord.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/Meta_coord.java
@@ -53,11 +53,11 @@ public class Meta_coord extends SingleDatabaseTestCase {
 		boolean result = true;
 
 		Connection con = dbre.getConnection();
-		String[] tables = { "variation_feature", "compressed_genotype_region", "transcript_variation", "read_coverage", "structural_variation_feature" };
+		String[] tables = { "variation_feature", "compressed_genotype_region", "transcript_variation", "structural_variation_feature" };
 		
 		try {
 			/*
-			 * Will check the presence of the variation_feature, transcript_variation, compressed_genotype, flanking_sequence, read_coverage
+			 * Will check the presence of the variation_feature, transcript_variation, compressed_genotype
 			 * and variation_group_feature entries in the meta_coord, when data present in those tables
 			 */
 			for (int i = 0; i < tables.length; i++) {

--- a/src/org/ensembl/healthcheck/testcase/variation/VariationForeignKeys.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/VariationForeignKeys.java
@@ -83,8 +83,6 @@ public class VariationForeignKeys extends SingleDatabaseTestCase {
 			result &= checkForOrphans(con, "population_genotype", "population_id", "population", "population_id", true);
 			result &= checkForOrphans(con, "population_genotype", "variation_id", "variation", "variation_id", true);
 			result &= checkForOrphans(con, "compressed_genotype_var", "variation_id", "variation", "variation_id", true);
-			result &= checkForOrphans(con, "read_coverage", "individual_id", "individual", "individual_id", true);
-			result &= checkForOrphans(con, "read_coverage", "seq_region_id", "seq_region", "seq_region_id", true);
 			result &= checkForOrphans(con, "individual_synonym", "individual_id", "individual", "individual_id", true);
 			result &= checkForOrphans(con, "population_synonym", "population_id", "population", "population_id", true);
 			result &= checkForOrphans(con, "tagged_variation_feature", "population_id", "population", "population_id", true);


### PR DESCRIPTION
The read_coverage table has been removed from the variation schema;
remove all tests on it and related meta, meta_coord entries.

NB: I haven't compiled and tested this, so please check before merging!
