### PR TITLE
Check gene_member and seq_member dnafrag_id FKs

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/compara/ForeignKeyDnafragId.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/ForeignKeyDnafragId.java
@@ -60,6 +60,8 @@ public class ForeignKeyDnafragId extends SingleDatabaseTestCase {
             result &= checkForOrphans(con, "dnafrag_region", "dnafrag_id", "dnafrag", "dnafrag_id");
             result &= checkForOrphans(con, "genomic_align", "dnafrag_id", "dnafrag", "dnafrag_id");
             result &= checkForOrphans(con, "constrained_element", "dnafrag_id", "dnafrag", "dnafrag_id");
+            result &= checkForOrphans(con, "gene_member", "dnafrag_id", "dnafrag", "dnafrag_id");
+            result &= checkForOrphans(con, "seq_member", "dnafrag_id", "dnafrag", "dnafrag_id");
 
         } else {
             ReportManager.correct(this, con, "NO ENTRIES in dnafrag table, so nothing to test IGNORED");


### PR DESCRIPTION
Updating a foreign key healthcheck, now that gene_member and seq_member have a dnafrag_id column.
