### PR TITLE
translated_proc'-pseduo' have translations in Vega.

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/generic/Pseudogene.java
+++ b/src/org/ensembl/healthcheck/testcase/generic/Pseudogene.java
@@ -77,6 +77,11 @@ public class Pseudogene extends SingleDatabaseTestCase {
 																											// polymorphic_pseudogene to have translations
 			qry += " and (gene.source='havana' or gene.source='WU')";
 		}
+    if (dbre.getType() == DatabaseType.SANGER_VEGA ||
+        dbre.getType() == DatabaseType.VEGA) {
+      // Vega allows translations on translated_processed_pseudogene-s
+      qry += " and gene.biotype != 'translated_processed_pseudogene'";
+    }
 
 		int rows = DBUtils.getRowCount(con, qry);
 		if (rows > 0) {


### PR DESCRIPTION
In vega there is an additional biotype translated_processed_pseudogenes
which have translations, so these should be skipped in the Pseudogene
healthcheck for those database types.

(Not sure what's happenning with the spacing here: I'm using two-spaces for an indent per the rest of the code. It aligns in my editor, which makes me think that somewhere else is using tabs).
