### PR TITLE
New --repair option for configurable test runner

### DIFF
--- a/database.defaults.properties
+++ b/database.defaults.properties
@@ -135,4 +135,5 @@ master.funcgen_schema   = master_schema_funcgen_74
 # The master.* settings are ignored if none of the Compare*Schema are run.
 #
 
+repair =
 

--- a/src/org/ensembl/healthcheck/ConfigurableTestRunner.java
+++ b/src/org/ensembl/healthcheck/ConfigurableTestRunner.java
@@ -124,6 +124,10 @@ public class ConfigurableTestRunner extends TestRunner {
 				configuration);
 		this.reporter = getReporter(this.reporterType);
 
+		String repair = configuration.getRepair().toLowerCase();
+		this.doRepair = (repair.equals("do") || repair.equals("1") || repair.equals("yes"));
+		this.showRepair = (repair.equals("show"));
+
 		DBUtils.setHostConfiguration((ConfigureHost) configuration);
 	}
 

--- a/src/org/ensembl/healthcheck/SystemPropertySetter.java
+++ b/src/org/ensembl/healthcheck/SystemPropertySetter.java
@@ -81,6 +81,14 @@ public class SystemPropertySetter {
 			System.setProperty("ignore.previous.checks",    configuration.getIgnorePreviousChecks());
 		}
 
+		if (configuration.isRepair()) {
+			// Used in:
+			//
+			// org.ensembl.healthcheck.testcase.EnsTestCase
+			//
+			System.setProperty("repair",    configuration.getRepair());
+		}
+
 		if (configuration.isSchemaFile()) {
 			// Used in:
 			//

--- a/src/org/ensembl/healthcheck/configuration/ConfigureMiscProperties.java
+++ b/src/org/ensembl/healthcheck/configuration/ConfigureMiscProperties.java
@@ -140,4 +140,13 @@ public interface ConfigureMiscProperties {
 
 	boolean isPassword();
 
+	// Used in:
+	//
+	// org.ensembl.healthcheck.testcase.EnsTestCase
+	//
+	@Option(longName = "repair", description = "Allow the tests to try to repair the database (if they can)")
+	String getRepair();
+
+	boolean isRepair();
+
 }


### PR DESCRIPTION
The option was missing from configurable-test-runner.sh, and we use it in a few tests.

I've added a --repair option that can take several values:
- "show" tells the tests to display the changes that are to apply to the
  database. It is the equivalent of --showrepair of run-healthcheck.sh
- "1", "yes", or "do" tells the tests to make the changes themselves

It works differently than in run-healthcheck.sh. In the latter, --repair and --showrepair could be used at the same time. I don't know if you guys want to preserve the original options
