### PR TITLE
EG-specific change to non-EG HC

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/generic/ProductionAnalysisLogicName.java
+++ b/src/org/ensembl/healthcheck/testcase/generic/ProductionAnalysisLogicName.java
@@ -66,8 +66,12 @@ public class ProductionAnalysisLogicName extends AbstractTemplatedTestCase {
     Set<String> productionDbVersion = getDbVersionProduction(dbre, coreLogicNames);
     result &= checkHasDbVersion(dbre, productionDbVersion, coreDbVersion, databaseType);
     result &= checkHasDbVersion(dbre, coreDbVersion, productionDbVersion, "production");
-    result &= testForIdentity(dbre, coreLogicNames, productionLogicNames, "production");
-    result &= testForIdentity(dbre, productionLogicNames, coreLogicNames, databaseType);
+    if(!dbre.isMultiSpecies()) {
+    	// checks are inappropriate for a multispecies database where individual mappings
+    	// are not stored in the production database
+    	result &= testForIdentity(dbre, coreLogicNames, productionLogicNames, "production");
+    	result &= testForIdentity(dbre, productionLogicNames, coreLogicNames, databaseType);
+    }
     return result;
   }
   


### PR DESCRIPTION
made HC skip production checks for multispecies collections where the species-analysis link will be missing from the production database (we use default webdata in this case)