### PR TITLE
Take into account genome_db.genome_component column...

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/eg_core/SeqRegionsConsistentWithComparaMaster.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_core/SeqRegionsConsistentWithComparaMaster.java
@@ -369,7 +369,7 @@ public class SeqRegionsConsistentWithComparaMaster extends AbstractControlledRow
 		if (genomeDbId==0) {
 			return false;
 		}		
-		throw new RuntimeException("Unexpected number of matching rows for " + productionName + "in master database!");			
+		throw new RuntimeException("Unexpected number of matching rows for " + productionName + " in master database!");			
 	}
 	
 	protected ResultSet fetchFromGenomeDbId(
@@ -378,7 +378,7 @@ public class SeqRegionsConsistentWithComparaMaster extends AbstractControlledRow
 			String genebuildStartDate, 
 			String column
 	) {
-		String sql = "select "+column+" from genome_db where name=? and assembly=? and genebuild=?";
+		String sql = "select "+column+" from genome_db where name=? and assembly=? and genebuild=? and genome_component IS NULL";
 		
 		ResultSet rs = null;
 		


### PR DESCRIPTION
...when retrieving genome_db entries from compara_master.

Test was failing for polyploid bread wheat for release 79, while it shouldn't. We now have to discriminate correctly genome_db_ids based on the genome_component value or its missing values.
Code now returns the only relevant one, and discards the component genome_db entries.