### PR TITLE
Allow production database name to be pulled from configs

### DIFF
--- a/src/org/ensembl/healthcheck/SystemPropertySetter.java
+++ b/src/org/ensembl/healthcheck/SystemPropertySetter.java
@@ -227,5 +227,14 @@ public class SystemPropertySetter {
 			//
 			System.setProperty("master.funcgen_schema",    configuration.getMasterFuncgenSchema());
 		}
+		if (configuration.isProductionDatabase()) {
+			// Used in:
+			//
+			// org.ensembl.healthcheck.testcase.EnsTestCase
+			//
+			System.setProperty("production.database", configuration.getProductionDatabase());
+		} else {
+			System.setProperty("production.database", "ensembl_production");
+		}
 	}
 }

--- a/src/org/ensembl/healthcheck/testcase/EnsTestCase.java
+++ b/src/org/ensembl/healthcheck/testcase/EnsTestCase.java
@@ -810,7 +810,7 @@ public abstract class EnsTestCase {
 		// return existing one if we already have it, otherwise use method above
 		// to find it
 		return productionDBRE != null ? productionDBRE
-				: getDatabaseRegistryEntryByPattern("ensembl_production");
+				: getDatabaseRegistryEntryByPattern(System.getProperty("production.database"));
 
 	}
 


### PR DESCRIPTION
We have a EG project (WormBase ParaSite) which has a production database name that is not ensembl_production.  As this is hard-coded into org.ensembl.healthcheck.testcase.EnsTestCase, it means we have to change this file each time (or stash it) when doing a git pull.  This commit allows the production database name to be included in the configs (as production.database); if it is not specified in the configs then the hard-coded ensembl_production is used.