### PR TITLE
Replaced hardcoded values for ens-staging1, ens-staging2 and ens-live…

### DIFF
--- a/src/org/ensembl/healthcheck/ParallelConfigurableTestRunner.java
+++ b/src/org/ensembl/healthcheck/ParallelConfigurableTestRunner.java
@@ -157,8 +157,8 @@ public class ParallelConfigurableTestRunner extends TestRunner {
         protected void submitJobs() {
 
                 int numberOfTestsRun = 0;
-
                 int jobNumber = 0;
+                String[] cmd;
                 List<String> jobNames = new ArrayList<String>();
                 String dir = System.getProperty("user.dir");
                 String runConfigurable = dir + File.separator + "run-configurable-testrunner.sh";
@@ -168,8 +168,20 @@ public class ParallelConfigurableTestRunner extends TestRunner {
 
                         String currentJobName = "Job_" + jobNumber;
 
-                        String[] cmd = {"bsub", "-q", "long", "-J", currentJobName, "-R", MEMORY_RUSAGE, "-M", MEMORY_RESERVATION, "-R", "select[myens_staging1<=800]", "-R", "select[myens_staging2<=800]", "-R", "select[myens_livemirror<=400]",
-                        "-R", "rusage[myens_staging1=10:myens_staging1=10:myens_livemirror=50]", "-o", "healthcheck_%J.out", "-e", "healthcheck_%J.err", runConfigurable, "-d", database, "--sessionID", "" + sessionID, "-c", DEFAULT_PROPERTIES_FILE };
+                        if ( configuration.getHost1() != null ) {  
+                                 cmd = new String[] {"bsub", "-q", "long", "-J", currentJobName, "-R", MEMORY_RUSAGE, "-M", MEMORY_RESERVATION, "-R", "select[my" + configuration.getHost().replace("-", "_") + "<=800]", "-R",
+                                 "select[my" + configuration.getHost1().replace("-", "_") + "<=800]", "-R",  "select[my" + configuration.getSecondaryHost().replace("-", "_") + "<=400]", "-R",
+                                 "rusage[my" + configuration.getHost().replace("-", "_") + "=10:my" + configuration.getHost1().replace("-", "_") + "=10:my" + configuration.getSecondaryHost().replace("-", "_") + "=50]", "-o", "healthcheck_%J.out", "-e", 
+                                 "healthcheck_%J.err", runConfigurable, "-d", database, "--sessionID", "" + sessionID, "-c", DEFAULT_PROPERTIES_FILE };
+                                 System.out.println("cmd:" + cmd);
+                        }
+                        else {
+                                 cmd = new String[] {"bsub", "-q", "long", "-J", currentJobName, "-R", MEMORY_RUSAGE, "-M", MEMORY_RESERVATION, "-R", "select[my" + configuration.getHost().replace("-", "_") + "<=800]", "-R", 
+                                 "select[my" + configuration.getSecondaryHost().replace("-", "_") + "<=400]", "-R", "rusage[my" + configuration.getHost().replace("-", "_") + "=10:my" + configuration.getSecondaryHost().replace("-", "_") + "=50]",
+                                 "-o", "healthcheck_%J.out", "-e", "healthcheck_%J.err", runConfigurable, "-d", database, "--sessionID", "" + sessionID, "-c", 
+                                 DEFAULT_PROPERTIES_FILE };
+                                 System.out.println("cmd:" + cmd);
+                        }
 
                         jobNames.add(currentJobName);
 

--- a/src/org/ensembl/healthcheck/SystemPropertySetter.java
+++ b/src/org/ensembl/healthcheck/SystemPropertySetter.java
@@ -43,7 +43,11 @@ public class SystemPropertySetter {
 		System.setProperty("output.password",    configuration.getOutputPassword());
 		System.setProperty("host",           configuration.getHost() );
 		System.setProperty("port",           configuration.getPort() );
+                System.setProperty("host1",           configuration.getHost1() );
+                System.setProperty("port1",           configuration.getPort1() );
 		System.setProperty("output.release", configuration.getOutputRelease() );
+                System.setProperty("secondary.host",           configuration.getSecondaryHost() );
+                System.setProperty("secondary.port",           configuration.getSecondaryPort() );
 
                 if (configuration.isTestDatabases()) {
                      String test_databases = "";


### PR DESCRIPTION
…mirror by host, host1 and secondary.host
Compiled OK:

ensembl-java:~/ensj-healthcheck (master) > ant clean jar
Buildfile: /nfs/users/nfs_e/ensembl/ensj-healthcheck/build.xml

clean:
   [delete] Deleting directory /nfs/users/nfs_e/ensembl/ensj-healthcheck/target/dist
   [delete] Deleting directory /nfs/users/nfs_e/ensembl/ensj-healthcheck/target/build
   [delete] Deleting directory /nfs/users/nfs_e/ensembl/ensj-healthcheck/test/classes

init:
    [mkdir] Created dir: /nfs/users/nfs_e/ensembl/ensj-healthcheck/target/build
    [mkdir] Created dir: /nfs/users/nfs_e/ensembl/ensj-healthcheck/target/dist
    [mkdir] Created dir: /nfs/users/nfs_e/ensembl/ensj-healthcheck/test/classes

compile:
    [javac] Compiling 569 source files to /nfs/users/nfs_e/ensembl/ensj-healthcheck/target/build
    [javac] Note: Some input files use or override a deprecated API.
    [javac] Note: Recompile with -Xlint:deprecation for details.
    [javac] Note: Some input files use unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.
     [echo] Run "ant jar" so the compiled classes are used by the command line scripts.

copy-resources:
     [copy] Copying 18 files to /nfs/users/nfs_e/ensembl/ensj-healthcheck/target/build/org/ensembl/healthcheck/gui

jar:
      [jar] Building jar: /nfs/users/nfs_e/ensembl/ensj-healthcheck/target/dist/ensj-healthcheck.jar

BUILD SUCCESSFUL
Total time: 13 seconds

Send the jobs with reportertype = Text in the config file and got the following resource requirement:

Job <3522553>, Job Name <Job_7>, User <ensembl>, Project <ensembl-core>, User G
                     roup <ensembl-core>, Status <DONE>, Queue <long>, Job Prio
                     rity <50>, Command </nfs/users/nfs_e/ensembl/ensj-healthch
                     eck/run-configurable-testrunner.sh -d monodelphis_domestic
                     a_variation_81.* --sessionID -1 -c database.release.defaul
                     ts.properties>, Share group charged </WTSI/ComputationalGe
                     nomics/Annotation/ensembl-grp/ensembl-core/ensembl>
Wed Jun  3 16:10:25: Submitted from host <farm3-head2>, CWD <$HOME/ensj-healthc
                     heck>, Output File <healthcheck_%J.out>, Error File <healt
                     hcheck_%J.err>, Requested Resources < select[(mem>2000)&&(
                     myens_staging1<=800)&&(myens_staging2<=800)&&(myens_livemi
                     rror<=400)] rusage[mem=2000,myens_staging1=10:myens_stagin

                     g2=10:myens_livemirror=50]>;

 MEMLIMIT
    1.9 G
Wed Jun  3 16:10:30: Started on <bc-31-2-13>, Execution Home </nfs/users/nfs_e/
                     ensembl>, Execution CWD </nfs/users/nfs_e/ensembl/ensj-hea
                     lthcheck>;
Wed Jun  3 16:10:33: Done successfully. The CPU time used is 3.7 seconds.

 MEMORY USAGE:
 MAX MEM: 46 Mbytes;  AVG MEM: 46 Mbytes

 SCHEDULING PARAMETERS:
           r15s   r1m  r15m   ut      pg    io   ls    it    tmp    swp    mem
 loadSched   -     -     -     -       -     -    -     -   200M   200M     -
 loadStop    -     -     -     -       -     -    -     -   101M     -      -

              poe nrt_windows adapter_windows  uptime pathdbsrv1_load
 loadSched     -           -               -       -               -
 loadStop      -           -               -       -               -

 EXCEPTION STATUS:  underrun

 RESOURCE REQUIREMENT DETAILS:
 Combined: select[((mem>2000)&&(myens_staging1<=800)&&(myens_staging2<=800)&&(m
                     yens_livemirror<=400)) && (type == any )] order[r15s:pg] r
                     usage[mem=2000.00,myens_livemirror=50.00:myens_staging1=10
                     .00:myens_staging2=10.00]
 Effective: select[((mem>2000)&&(myens_staging1<=800)&&(myens_staging2<=800)&&(
                     myens_livemirror<=400)) && (type == any )] order[r15s:pg]
                     rusage[mem=2000.00,myens_livemirror=50.00,myens_staging1=1
                     0.00,myens_staging2=10.00]


There was a typo in rusage as myens_staging1 was mentioned twice...
