### PR TITLE
Split HCs into two to allow different checks to be run separately

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/generic/SeqRegionsTopLevelRefSeq.java
+++ b/src/org/ensembl/healthcheck/testcase/generic/SeqRegionsTopLevelRefSeq.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (C) 2003 EBI, GRL
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package org.ensembl.healthcheck.testcase.generic;
+
+import java.sql.Connection;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+import org.ensembl.healthcheck.DatabaseRegistryEntry;
+import org.ensembl.healthcheck.DatabaseType;
+import org.ensembl.healthcheck.ReportManager;
+import org.ensembl.healthcheck.Team;
+import org.ensembl.healthcheck.testcase.SingleDatabaseTestCase;
+import org.ensembl.healthcheck.util.DBUtils;
+import org.ensembl.healthcheck.util.SqlTemplate;
+
+/**
+ * Checks that seq regions which should have refseq annotation do so
+ */
+
+public class SeqRegionsTopLevelRefSeq extends SingleDatabaseTestCase {
+
+	/**
+	 * Create a new SeqRegionsTopLevel testcase.
+	 */
+	public SeqRegionsTopLevelRefSeq() {
+
+		addToGroup("post_genebuild");
+		addToGroup("pre-compara-handover");
+		addToGroup("post-compara-handover");
+		addToGroup("post-projection");
+
+		setDescription("Check that all seq_regions comprising genes are marked as toplevel in seq_region_attrib, and that there is at least one toplevel seq_region. Also check that all toplevel seq regions are marked as such, and no seq regions that are marked as toplevel are not toplevel. Will check as well if the toplevel seqregions have information in the assembly table");
+		setTeamResponsible(Team.GENEBUILD);
+	}
+
+	/**
+	 * Data is only tested in core database, as the tables are in sync
+	 */
+	public void types() {
+
+		removeAppliesToType(DatabaseType.OTHERFEATURES);
+		removeAppliesToType(DatabaseType.ESTGENE);
+		removeAppliesToType(DatabaseType.RNASEQ);
+		removeAppliesToType(DatabaseType.CDNA);
+
+	}
+
+	/**
+	 * Run the test.
+	 * 
+	 * @param dbre
+	 *            The database to use.
+	 * @return true if the test passed.
+	 * 
+	 */
+	public boolean run(DatabaseRegistryEntry dbre) {
+
+		boolean result = true;
+
+		Connection con = dbre.getConnection();
+
+		String assemblyAccession = DBUtils.getMetaValue(con,
+				"assembly.accession");
+
+		if (!StringUtils.isEmpty(assemblyAccession)
+				&& assemblyAccession.contains("GCA")) {
+
+			int topLevelAttribTypeID = getAttribTypeID(con, "toplevel");
+			if (topLevelAttribTypeID == -1) {
+				return false;
+			}
+
+			int karyotypeAttribTypeID = getAttribTypeID(con, "karyotype_rank");
+			if (karyotypeAttribTypeID == -1) {
+				return false;
+			}
+
+			Set<String> synsRefSeqGenomic = getSyns(dbre, "RefSeq_genomic");
+			Set<String> topLevelRegions = getRegions(dbre, topLevelAttribTypeID);
+			result &= checkSynonyms(dbre, synsRefSeqGenomic, topLevelRegions,
+					"RefSeq_genomic", "toplevel");
+			Set<String> synsINSDC = getSyns(dbre, "INSDC");
+			Set<String> karyotypeRegions = getRegions(dbre,
+					karyotypeAttribTypeID);
+			result &= checkSynonyms(dbre, synsINSDC, karyotypeRegions, "INSDC",
+					"chromosome");
+			Set<String> patchRegions = getPatches(dbre);
+			result &= checkSynonyms(dbre, synsRefSeqGenomic, patchRegions,
+					"RefSeq_genomic", "patch");
+		}
+
+		return result;
+
+	} // run
+
+	// --------------------------------------------------------------------------
+
+	private int getAttribTypeID(Connection con, String attrib) {
+
+		String val = DBUtils.getRowColumnValue(con,
+				"SELECT attrib_type_id FROM attrib_type WHERE code='" + attrib
+						+ "'");
+		if (val == null || val.equals("")) {
+			ReportManager.problem(this, con,
+					"Can't find a seq_region attrib_type with code '" + attrib
+							+ "', exiting");
+			return -1;
+		}
+		int attribTypeID = Integer.parseInt(val);
+
+		logger.info("attrib_type_id for '" + attrib + "': " + attribTypeID);
+
+		return attribTypeID;
+
+	}
+
+	// --------------------------------------------------------------------------
+
+	private <T extends CharSequence> boolean checkSynonyms(
+			DatabaseRegistryEntry dbre, Collection<T> syns,
+			Collection<T> regions, String dbName, String type) {
+
+		boolean result = true;
+		
+		Connection con = dbre.getConnection();
+
+		Set<T> missing = new HashSet<T>(regions);
+		missing.removeAll(syns);
+
+		if (!missing.isEmpty()) {
+			ReportManager.problem(this, con, missing.size() + " " + type
+					+ " region(s) do not have a " + dbName + " synonym");
+			result = false;
+		} else {
+			ReportManager.correct(this, con, "All " + type
+					+ " regions have a synonym for " + dbName);
+		}
+
+		return result;
+	}
+
+	private Set<String> getSyns(DatabaseRegistryEntry dbre, String dbName) {
+		SqlTemplate t = DBUtils.getSqlTemplate(dbre);
+		String sql = "SELECT DISTINCT s.name FROM seq_region s, seq_region_synonym ss, external_db e WHERE s.seq_region_id = ss.seq_region_id AND ss.external_db_id = e.external_db_id AND e.db_name = ?";
+		List<String> results = t.queryForDefaultObjectList(sql, String.class,
+				dbName);
+		return new HashSet<String>(results);
+	}
+
+	private Set<String> getRegions(DatabaseRegistryEntry dbre, int attribTypeID) {
+		SqlTemplate t = DBUtils.getSqlTemplate(dbre);
+		String sql = "SELECT DISTINCT s.name FROM seq_region s, seq_region_attrib sa WHERE s.seq_region_id = sa.seq_region_id AND s.name NOT LIKE 'CHR_%' AND s.name NOT LIKE 'LRG%' AND s.name NOT LIKE 'MT' AND attrib_type_id = ? AND s.seq_region_id NOT IN (SELECT s.seq_region_id FROM seq_region s, attrib_type at, seq_region_attrib sa WHERE s.seq_region_id = sa.seq_region_id AND sa.attrib_type_id = at.attrib_type_id AND code = 'codon_table') ";
+		List<String> results = t.queryForDefaultObjectList(sql, String.class,
+				attribTypeID);
+		return new HashSet<String>(results);
+	}
+
+	private Set<String> getPatches(DatabaseRegistryEntry dbre) {
+		SqlTemplate t = DBUtils.getSqlTemplate(dbre);
+		String sql = "SELECT DISTINCT s1.name FROM seq_region s1, seq_region s2, coord_system cs1, coord_system cs2 WHERE s2.name = concat('CHR_', s1.name) AND s1.coord_system_id = cs1.coord_system_id AND cs1.name = 'scaffold' AND s2.coord_system_id = cs2.coord_system_id AND cs2.name = 'chromosome'";
+		List<String> results = t.queryForDefaultObjectList(sql, String.class);
+		return new HashSet<String>(results);
+	}
+
+} // SeqRegionsTopLevel

--- a/src/org/ensembl/healthcheck/testcase/generic/StableID.java
+++ b/src/org/ensembl/healthcheck/testcase/generic/StableID.java
@@ -14,26 +14,21 @@
  * limitations under the License.
  */
 
-
 package org.ensembl.healthcheck.testcase.generic;
 
 import java.sql.Connection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
 
 import org.ensembl.healthcheck.DatabaseRegistryEntry;
 import org.ensembl.healthcheck.DatabaseType;
 import org.ensembl.healthcheck.ReportManager;
-import org.ensembl.healthcheck.Species;
 import org.ensembl.healthcheck.Team;
 import org.ensembl.healthcheck.testcase.Priority;
 import org.ensembl.healthcheck.testcase.SingleDatabaseTestCase;
 import org.ensembl.healthcheck.util.DBUtils;
 
 /**
- * Checks stable_id data to ensure they are populated, have no orphan references, and have valid versions. Also prints some
- * examples from the table for checking by eye.
+ * Checks to ensure all genes, transcripts, translations and exons have unique
+ * stable IDs
  * 
  * <p>
  * Group is <b>check_stable_ids </b>
@@ -49,12 +44,12 @@ public class StableID extends SingleDatabaseTestCase {
 	 * Create a new instance of StableID.
 	 */
 	public StableID() {
-		
+
 		addToGroup("post_genebuild");
 		addToGroup("pre-compara-handover");
 		addToGroup("post-compara-handover");
-                addToGroup("post-projection");
-		
+		addToGroup("post-projection");
+
 		setDescription("Checks stable_id data is valid.");
 		setPriority(Priority.RED);
 		setEffect("Compara will have invalid stable IDs.");
@@ -63,19 +58,17 @@ public class StableID extends SingleDatabaseTestCase {
 		setSecondTeamResponsible(Team.GENEBUILD);
 	}
 
+	public void types() {
 
-        public void types() {
+		removeAppliesToType(DatabaseType.CDNA);
 
-                removeAppliesToType(DatabaseType.CDNA);
-
-        }
-
+	}
 
 	/**
 	 * Run the test.
 	 * 
 	 * @param dbre
-	 *          The database to use.
+	 *            The database to use.
 	 * @return true if the test passed.
 	 * 
 	 */
@@ -90,28 +83,19 @@ public class StableID extends SingleDatabaseTestCase {
 		result &= checkStableIDs(con, "transcript");
 		result &= checkStableIDs(con, "gene");
 
-		// there are several species where ID mapping is not done
-		Species s = dbre.getSpecies();
-		if (s != null && s != Species.CAENORHABDITIS_ELEGANS && s != Species.DROSOPHILA_MELANOGASTER && s != Species.SACCHAROMYCES_CEREVISIAE && s != Species.ANOPHELES_GAMBIAE && s != Species.UNKNOWN) {
-			if (dbre.getType() == DatabaseType.CORE) {// for sangervega, do not check the prefixes
-				result &= checkPrefixes(dbre);
-        			result &= checkStableIDEventTypes(con);
-                                result = checkStableIDTimestamps(con);
-                        }
-		}
-
 		return result;
 	}
 
 	/**
-	 * Checks that the typeName_stable_id table is valid. The table is valid if it has >0 rows, and there are no orphan references
-	 * between typeName table and typeName_stable_id. Also prints some example data from the typeName_stable_id table via
-	 * ReportManager.info().
+	 * Checks that the typeName_stable_id table is valid. The table is valid if
+	 * it has >0 rows, and there are no orphan references between typeName table
+	 * and typeName_stable_id. Also prints some example data from the
+	 * typeName_stable_id table via ReportManager.info().
 	 * 
 	 * @param con
-	 *          connection to run queries on.
+	 *            connection to run queries on.
 	 * @param typeName
-	 *          name of the type to check, e.g. "exon"
+	 *            name of the type to check, e.g. "exon"
 	 * @return true if the table and references are valid, otherwise false.
 	 */
 	public boolean checkStableIDs(Connection con, String typeName) {
@@ -119,181 +103,33 @@ public class StableID extends SingleDatabaseTestCase {
 		boolean result = true;
 
 		String stableIDtable = typeName;
-		int nullStableIDs = DBUtils.getRowCount(con, "SELECT COUNT(1) FROM " + stableIDtable + " WHERE stable_id IS NULL");
+		int nullStableIDs = DBUtils.getRowCount(con, "SELECT COUNT(1) FROM "
+				+ stableIDtable + " WHERE stable_id IS NULL");
 
 		if (nullStableIDs > 0) {
-			ReportManager.problem(this, con, stableIDtable + " table has NULL stable_ids");
+			ReportManager.problem(this, con, stableIDtable
+					+ " table has NULL stable_ids");
 			result = false;
 		}
 
-		// check for duplicate stable IDs 
+		// check for duplicate stable IDs
 		// to find which records are duplicated use
 		// SELECT exon_id, stable_id, COUNT(*) FROM exon_stable_id GROUP BY
 		// stable_id HAVING COUNT(*) > 1;
 		// this will give the internal IDs for *one* of each of the duplicates
 		// if there are only a few then reassign the stable IDs of one of the
 		// duplicates
-		int duplicates = DBUtils.getRowCount(con, "SELECT COUNT(stable_id)-COUNT(DISTINCT stable_id) FROM " + stableIDtable);
+		int duplicates = DBUtils.getRowCount(con,
+				"SELECT COUNT(stable_id)-COUNT(DISTINCT stable_id) FROM "
+						+ stableIDtable);
 		if (duplicates > 0) {
-			ReportManager.problem(this, con, stableIDtable + " has " + duplicates + " duplicate stable IDs (versions not checked)");
+			ReportManager.problem(this, con, stableIDtable + " has "
+					+ duplicates
+					+ " duplicate stable IDs (versions not checked)");
 			result = false;
 		}
 
 		return result;
-	}
-
-	// -----------------------------------------------------------
-	/**
-	 * Check that all stable IDs in the table have the correct prefix. The prefix is defined in Species.java
-	 */
-	private boolean checkPrefixes(DatabaseRegistryEntry dbre) {
-
-		boolean result = true;
-
-		Connection con = dbre.getConnection();
-
-		Map<String, String> tableToLetter = new HashMap<String, String>();
-		tableToLetter.put("gene", "G");
-		tableToLetter.put("transcript", "T");
-		tableToLetter.put("translation", "P");
-		tableToLetter.put("exon", "E");
-
-		Iterator<String> it = tableToLetter.keySet().iterator();
-		while (it.hasNext()) {
-
-			String type = (String) it.next();
-			String table = type;
-
-			String prefix = Species.getStableIDPrefixForSpecies(dbre.getSpecies(), dbre.getType());
-			if (prefix == null || prefix == "") {
-				ReportManager.problem(this, con, "Can't get stable ID prefix for " + dbre.getSpecies().toString() + " - please add to Species.java");
-				result = false;
-			} else {
-				if (prefix.equalsIgnoreCase("IGNORE")) {
-					return true;
-				}
-				String prefixLetter = prefix + (String) tableToLetter.get(type);
-				int wrong = DBUtils.getRowCount(con, "SELECT COUNT(*) FROM " + table + " WHERE stable_id NOT LIKE '" + prefixLetter + "%' AND stable_id NOT LIKE 'LRG%'");
-				if (wrong > 0) {
-					ReportManager.problem(this, con, wrong + " rows in " + table + " do not have the correct (" + prefixLetter + ") prefix");
-					result = false;
-				}
-			}
-		}
-
-		return result;
-
-	}
-
-	// -----------------------------------------------------------
-	/**
-	 * Check for any stable ID events where the 'type' column does not match the identifier type.
-	 * 
-	 */
-	private boolean checkStableIDEventTypes(Connection con) {
-
-		boolean result = true;
-
-		String[] types = { "gene", "transcript", "translation", "exon" };
-
-
-		for (int i = 0; i < types.length; i++) {
-
-			String type = types[i];
-
-			String prefix = getPrefixForType(con, type);
-
-			String sql = "SELECT COUNT(*) FROM stable_id_event WHERE (old_stable_id LIKE '" + prefix + "%' OR new_stable_id LIKE '" + prefix + "%') AND type != '" + type + "'";
-
-			int rows = DBUtils.getRowCount(con, sql);
-
-			if (rows > 0) {
-
-				ReportManager.problem(this, con, rows + " rows of type " + type + " (prefix " + prefix + ") in stable_id_event have identifiers that do not correspond to " + type + "s");
-				result = false;
-
-			}
-
-                        // check for invalid or missing stable ID versions
-                        int nInvalidVersions = DBUtils.getRowCount(con, "SELECT COUNT(*) AS " + type + "_with_invalid_version" + " FROM " + type + " WHERE version < 1 OR version IS NULL;");
-
-                        if (nInvalidVersions > 0) {
-                                ReportManager.problem(this, con, "Invalid versions in " + type);
-                                DBUtils.printRows(this, con, "SELECT DISTINCT(version) FROM " + type);
-                                result = false;
-                        }
-
-                        // make sure stable ID versions in the typeName table matches those in stable_id_event
-                        // for the latest mapping_session
-                        String mappingSessionId = DBUtils.getRowColumnValue(con, "SELECT mapping_session_id FROM mapping_session " + "ORDER BY created DESC LIMIT 1");
-
-                        if (mappingSessionId.equals("")) {
-                                ReportManager.info(this, con, "No mapping_session found");
-                                return result;
-                        }
-
-                        int nVersionMismatch = DBUtils.getRowCount(con, "SELECT COUNT(*) FROM stable_id_event sie, " + type + " si WHERE sie.mapping_session_id = " + Integer.parseInt(mappingSessionId)
-                                        + " AND sie.new_stable_id = si.stable_id AND sie.new_version <> si.version");
-
-                        if (nVersionMismatch > 0) {
-                                ReportManager.problem(this, con, "Version mismatch between " + nVersionMismatch + " " + type + " versions in and stable_id_event");
-                                DBUtils.printRows(this, con, "SELECT si.stable_id FROM stable_id_event sie, " + type + " si WHERE sie.mapping_session_id = " + Integer.parseInt(mappingSessionId)
-                                                + " AND sie.new_stable_id = si.stable_id AND sie.new_version <> si.version");
-                                result = false;
-                        }
-
-		}
-		return result;
-
-	}
-
-	// -----------------------------------------------------------
-
-	private String getPrefixForType(Connection con, String type) {
-
-		String prefix = "";
-
-		// hope the first row of the type table is correct
-		String stableID = DBUtils.getRowColumnValue(con, "SELECT stable_id FROM " + type + " LIMIT 1");
-
-		prefix = stableID.replaceAll("[0-9]", "");
-
-		if (prefix.equals("")) {
-			System.err.println("Error, can't get prefix for " + type + " from stable ID " + stableID);
-		}
-
-		return prefix;
-
-	}
-
-	// -----------------------------------------------------------
-	/**
-
-	 * 
-	 */
-	private boolean checkStableIDTimestamps(Connection con) {
-
-		boolean result = true;
-
-		String[] types = { "gene", "transcript", "translation", "exon" };
-
-		for (int i = 0; i < types.length; i++) {
-
-			String table = types[i];
-
-			String sql = "SELECT COUNT(*) FROM " + table + " WHERE created_date=0 OR modified_date=0";
-
-			int rows = DBUtils.getRowCount(con, sql);
-
-			if (rows > 0) {
-
-				ReportManager.problem(this, con, rows + " rows in " + table + " have created or modified dates of 0000-00-00 00:00:00");
-				result = false;
-
-			}
-		}
-		return result;
-
 	}
 
 }

--- a/src/org/ensembl/healthcheck/testcase/generic/StableIDMapping.java
+++ b/src/org/ensembl/healthcheck/testcase/generic/StableIDMapping.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ensembl.healthcheck.testcase.generic;
+
+import java.sql.Connection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.ensembl.healthcheck.DatabaseRegistryEntry;
+import org.ensembl.healthcheck.DatabaseType;
+import org.ensembl.healthcheck.ReportManager;
+import org.ensembl.healthcheck.Species;
+import org.ensembl.healthcheck.Team;
+import org.ensembl.healthcheck.testcase.Priority;
+import org.ensembl.healthcheck.testcase.SingleDatabaseTestCase;
+import org.ensembl.healthcheck.util.DBUtils;
+
+/**
+ * Checks that mapped stable IDs are correct and mapping tables are correctly
+ * populated
+ * 
+ * <p>
+ * Group is <b>check_stable_ids </b>
+ * </p>
+ * 
+ * <p>
+ * To be run after the stable ids have been assigned.
+ * </p>
+ */
+public class StableIDMapping extends SingleDatabaseTestCase {
+
+	/**
+	 * Create a new instance of StableID.
+	 */
+	public StableIDMapping() {
+
+		addToGroup("post_genebuild");
+		addToGroup("pre-compara-handover");
+		addToGroup("post-compara-handover");
+		addToGroup("post-projection");
+
+		setDescription("Checks stable_id mapping data is valid.");
+		setPriority(Priority.RED);
+		setEffect("Compara will have invalid stable IDs.");
+		setFix("Re-run stable ID mapping or fix manually.");
+		setTeamResponsible(Team.CORE);
+		setSecondTeamResponsible(Team.GENEBUILD);
+	}
+
+	public void types() {
+
+		removeAppliesToType(DatabaseType.CDNA);
+
+	}
+
+	/**
+	 * Run the test.
+	 * 
+	 * @param dbre
+	 *            The database to use.
+	 * @return true if the test passed.
+	 * 
+	 */
+	public boolean run(DatabaseRegistryEntry dbre) {
+
+		boolean result = true;
+
+		Connection con = dbre.getConnection();
+
+		// there are several species where ID mapping is not done
+		Species s = dbre.getSpecies();
+		if (s != null && s != Species.CAENORHABDITIS_ELEGANS
+				&& s != Species.DROSOPHILA_MELANOGASTER
+				&& s != Species.SACCHAROMYCES_CEREVISIAE
+				&& s != Species.ANOPHELES_GAMBIAE && s != Species.UNKNOWN) {
+			if (dbre.getType() == DatabaseType.CORE) {// for sangervega, do not
+														// check the prefixes
+				result &= checkPrefixes(dbre);
+				result &= checkStableIDEventTypes(con);
+				result = checkStableIDTimestamps(con);
+			}
+		}
+
+		return result;
+	}
+
+	// -----------------------------------------------------------
+	/**
+	 * Check that all stable IDs in the table have the correct prefix. The
+	 * prefix is defined in Species.java
+	 */
+	private boolean checkPrefixes(DatabaseRegistryEntry dbre) {
+
+		boolean result = true;
+
+		Connection con = dbre.getConnection();
+
+		Map<String, String> tableToLetter = new HashMap<String, String>();
+		tableToLetter.put("gene", "G");
+		tableToLetter.put("transcript", "T");
+		tableToLetter.put("translation", "P");
+		tableToLetter.put("exon", "E");
+
+		Iterator<String> it = tableToLetter.keySet().iterator();
+		while (it.hasNext()) {
+
+			String type = (String) it.next();
+			String table = type;
+
+			String prefix = Species.getStableIDPrefixForSpecies(
+					dbre.getSpecies(), dbre.getType());
+			if (prefix == null || prefix == "") {
+				ReportManager.problem(this, con,
+						"Can't get stable ID prefix for "
+								+ dbre.getSpecies().toString()
+								+ " - please add to Species.java");
+				result = false;
+			} else {
+				if (prefix.equalsIgnoreCase("IGNORE")) {
+					return true;
+				}
+				String prefixLetter = prefix + (String) tableToLetter.get(type);
+				int wrong = DBUtils.getRowCount(con, "SELECT COUNT(*) FROM "
+						+ table + " WHERE stable_id NOT LIKE '" + prefixLetter
+						+ "%' AND stable_id NOT LIKE 'LRG%'");
+				if (wrong > 0) {
+					ReportManager.problem(this, con, wrong + " rows in "
+							+ table + " do not have the correct ("
+							+ prefixLetter + ") prefix");
+					result = false;
+				}
+			}
+		}
+
+		return result;
+
+	}
+
+	// -----------------------------------------------------------
+	/**
+	 * Check for any stable ID events where the 'type' column does not match the
+	 * identifier type.
+	 * 
+	 */
+	private boolean checkStableIDEventTypes(Connection con) {
+
+		boolean result = true;
+
+		String[] types = { "gene", "transcript", "translation", "exon" };
+
+		for (int i = 0; i < types.length; i++) {
+
+			String type = types[i];
+
+			String prefix = getPrefixForType(con, type);
+
+			String sql = "SELECT COUNT(*) FROM stable_id_event WHERE (old_stable_id LIKE '"
+					+ prefix
+					+ "%' OR new_stable_id LIKE '"
+					+ prefix
+					+ "%') AND type != '" + type + "'";
+
+			int rows = DBUtils.getRowCount(con, sql);
+
+			if (rows > 0) {
+
+				ReportManager
+						.problem(
+								this,
+								con,
+								rows
+										+ " rows of type "
+										+ type
+										+ " (prefix "
+										+ prefix
+										+ ") in stable_id_event have identifiers that do not correspond to "
+										+ type + "s");
+				result = false;
+
+			}
+
+			// check for invalid or missing stable ID versions
+			int nInvalidVersions = DBUtils.getRowCount(con,
+					"SELECT COUNT(*) AS " + type + "_with_invalid_version"
+							+ " FROM " + type
+							+ " WHERE version < 1 OR version IS NULL;");
+
+			if (nInvalidVersions > 0) {
+				ReportManager.problem(this, con, "Invalid versions in " + type);
+				DBUtils.printRows(this, con, "SELECT DISTINCT(version) FROM "
+						+ type);
+				result = false;
+			}
+
+			// make sure stable ID versions in the typeName table matches those
+			// in stable_id_event
+			// for the latest mapping_session
+			String mappingSessionId = DBUtils.getRowColumnValue(con,
+					"SELECT mapping_session_id FROM mapping_session "
+							+ "ORDER BY created DESC LIMIT 1");
+
+			if (mappingSessionId.equals("")) {
+				ReportManager.info(this, con, "No mapping_session found");
+				return result;
+			}
+
+			int nVersionMismatch = DBUtils
+					.getRowCount(
+							con,
+							"SELECT COUNT(*) FROM stable_id_event sie, "
+									+ type
+									+ " si WHERE sie.mapping_session_id = "
+									+ Integer.parseInt(mappingSessionId)
+									+ " AND sie.new_stable_id = si.stable_id AND sie.new_version <> si.version");
+
+			if (nVersionMismatch > 0) {
+				ReportManager.problem(this, con, "Version mismatch between "
+						+ nVersionMismatch + " " + type
+						+ " versions in and stable_id_event");
+				DBUtils.printRows(
+						this,
+						con,
+						"SELECT si.stable_id FROM stable_id_event sie, "
+								+ type
+								+ " si WHERE sie.mapping_session_id = "
+								+ Integer.parseInt(mappingSessionId)
+								+ " AND sie.new_stable_id = si.stable_id AND sie.new_version <> si.version");
+				result = false;
+			}
+
+		}
+		return result;
+
+	}
+
+	// -----------------------------------------------------------
+
+	private String getPrefixForType(Connection con, String type) {
+
+		String prefix = "";
+
+		// hope the first row of the type table is correct
+		String stableID = DBUtils.getRowColumnValue(con,
+				"SELECT stable_id FROM " + type + " LIMIT 1");
+
+		prefix = stableID.replaceAll("[0-9]", "");
+
+		if (prefix.equals("")) {
+			System.err.println("Error, can't get prefix for " + type
+					+ " from stable ID " + stableID);
+		}
+
+		return prefix;
+
+	}
+
+	// -----------------------------------------------------------
+	/**
+
+	 * 
+	 */
+	private boolean checkStableIDTimestamps(Connection con) {
+
+		boolean result = true;
+
+		String[] types = { "gene", "transcript", "translation", "exon" };
+
+		for (int i = 0; i < types.length; i++) {
+
+			String table = types[i];
+
+			String sql = "SELECT COUNT(*) FROM " + table
+					+ " WHERE created_date=0 OR modified_date=0";
+
+			int rows = DBUtils.getRowCount(con, sql);
+
+			if (rows > 0) {
+
+				ReportManager
+						.problem(
+								this,
+								con,
+								rows
+										+ " rows in "
+										+ table
+										+ " have created or modified dates of 0000-00-00 00:00:00");
+				result = false;
+
+			}
+		}
+		return result;
+
+	}
+
+}


### PR DESCRIPTION
I've separated the contents of two different checks to allow different sets of checks to be made independently. The main reason for doing this is to allow EG databases to ignore stable ID mapping and RefSeq checks, which are generally not relevant for EG databases. I've run these on human and they've not changed the outcome (there is still 1 failure for SeqRegionsTopLevelRefSeq which was there in SeqRegionsTopLevel anyway)