### PR TITLE
Master

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/eg_core/meta_keys.txt
+++ b/src/org/ensembl/healthcheck/testcase/eg_core/meta_keys.txt
@@ -44,6 +44,7 @@ sample.gene_param
 sample.gene_text
 sample.location_param
 sample.location_text
+sample.polyploid_region
 sample.search_text
 sample.structural_param
 sample.structural_text

--- a/src/org/ensembl/healthcheck/testcase/eg_core/meta_keys.txt
+++ b/src/org/ensembl/healthcheck/testcase/eg_core/meta_keys.txt
@@ -25,9 +25,9 @@ genebuild.method
 genebuild.projection_source_db
 genebuild.start_date
 genebuild.version
+interpro.version
 interproscan.date
 interproscan.version
-interpro.version
 liftover.mapping
 patch
 ploidy


### PR DESCRIPTION
Adding 'sample.polyploid_region' used for wheat currently, but more plants in future. This meta-key is picked up by the EG web code to add the 'view sample polyploid region'.