### PR TITLE
Fix protein feature ends after translation problem

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/eg_core/EgProteinFeatureTranslation.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_core/EgProteinFeatureTranslation.java
@@ -216,15 +216,15 @@ public class EgProteinFeatureTranslation extends AbstractEgCoreTestCase {
 
 				if (translationLengths.get(translationID) != null) {
 					// some codons can only be 2 bp ?!?
-					int minTranslationLength = (((Integer) translationLengths
-							.get(translationID)).intValue() + 2) / 3;
+					int maxTranslationLength = (((Integer) translationLengths
+							.get(translationID)).intValue() + 3) / 3;
 					int fl = rs.getInt("seq_end");
-					if (fl > minTranslationLength) {
+					if (fl > maxTranslationLength) {
 						result = false;
 						String msg = "Protein feature " + proteinFeatureID
 								+ "(" + rs.getString(4) + "/" + rs.getString(5)
 								+ ") ends at " + fl + " which is beyond the "
-								+ minTranslationLength
+								+ maxTranslationLength
 								+ " length of the translation " + translationID;
 						thisDBFeatures.add(msg);
 					}


### PR DESCRIPTION
Exons do not always start and end in the same phase.  The following:

-/---/---/---/---/--

has a translation length of 15nt but can result in a peptide sequence length of 6.

Must therefore add on 3, instead of 2.

(Ideally, this healthcheck should take exon start and exon phases into account)