### PR TITLE
not relevant to otherfeatures

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/generic/CanonicalTranscriptCoding.java
+++ b/src/org/ensembl/healthcheck/testcase/generic/CanonicalTranscriptCoding.java
@@ -46,6 +46,7 @@ public class CanonicalTranscriptCoding extends SingleDatabaseTestCase {
 
                 removeAppliesToType(DatabaseType.SANGER_VEGA);
                 removeAppliesToType(DatabaseType.VEGA);
+                removeAppliesToType(DatabaseType.OTHERFEATURES);
 
         }
 


### PR DESCRIPTION
I don't think this check is relevant to otherfeatures databases - but I don't know how these are used in Ensembl