### PR TITLE
ignoring some universally created directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /bin/
 *.iml
 /.idea
+db_checksums/
+external_reports/
+perlcode/


### PR DESCRIPTION
Hopefully minor... Every run creates these files, but unless we want to check them in, I guess we should ignore them.