### PR TITLE
Use exec so that java's exit code is passed on

### DIFF
--- a/run-configurable-testrunner.sh
+++ b/run-configurable-testrunner.sh
@@ -29,5 +29,5 @@ if [ -z "$JAVA_OPTS" ]; then
     JAVA_OPTS=-Xmx4g
 fi
 
-java $JAVA_OPTS -Djava.util.logging.config.file=config/logger/logging.properties org.ensembl.healthcheck.ConfigurableTestRunner $*
+exec java $JAVA_OPTS -Djava.util.logging.config.file=config/logger/logging.properties org.ensembl.healthcheck.ConfigurableTestRunner $*
 


### PR DESCRIPTION
This way we can use the script's exit code
Also, we avoid a bash process hanging around :)