### PR TITLE
seq_region names are not necessarily unique across the whole table

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/variation/ForeignKeyCoreId.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ForeignKeyCoreId.java
@@ -129,7 +129,7 @@ public class ForeignKeyCoreId extends MultiDatabaseTestCase {
 										+ ".seq_region src on (src.name=srv.name) join "
 										+ dbrcore.getName()
 										+ ".coord_system cs on (cs.coord_system_id=src.coord_system_id) "+
-										"WHERE csv.attrib = 'default_version' AND cs.attrib='default_version' AND src.seq_region_id != srv.seq_region_id");
+										"WHERE csv.attrib = 'default_version' AND cs.attrib='default_version' AND csv.name = cs.name AND src.seq_region_id != srv.seq_region_id");
 
 				if (rows > 0) {
 					ReportManager


### PR DESCRIPTION
In such cases, this HC was erroneously reporting mismatches. But names _should_ be unique for a given coord_system level, so add that to the conditions for comparing between core and variation dbs