### PR TITLE
Allow for extra whitespace between month and day

### DIFF
--- a/healthcheck_txt2html.pl
+++ b/healthcheck_txt2html.pl
@@ -427,7 +427,7 @@ sub get_run_date_time {
   my $time_line = `grep 'Results reported' $input_file`;
   
   if ($time_line) {
-    $time_line =~ /Results\sreported\sat\s\w+\s(\w+)\s(\d+)\s(\d+:\d+:\d+)\s(\d+)/;
+    $time_line =~ /Results\sreported\sat\s\w+\s(\w+)\s+(\d+)\s(\d+:\d+:\d+)\s(\d+)/;
     my $month = $1;
     my $day   = $2;
     my $time  = $3;


### PR DESCRIPTION
Modified to allow date string to be parsed with extra white space between month and day for single digit days e.g.
Results reported at Wed Jan  3 11:02:39 2018