### PR TITLE
Create HealthCheck group VariationPreHandover

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/variation/AlleleFrequencies.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/AlleleFrequencies.java
@@ -38,7 +38,6 @@ public class AlleleFrequencies extends SingleDatabaseTestCase {
 	 * Creates a new instance of Check Allele Frequencies
 	 */
 	public AlleleFrequencies() {
-		//addToGroup("variation-long");
 		setHintLongRunning(true);
 		setDescription("Check that the allele frequencies add up to 1");
 		setTeamResponsible(Team.VARIATION);

--- a/src/org/ensembl/healthcheck/testcase/variation/CheckChar.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/CheckChar.java
@@ -38,7 +38,6 @@ public class CheckChar extends SingleDatabaseTestCase {
 	 */
 	public CheckChar() {
 
-		addToGroup("variation-release");
 		setDescription("Check that imported names/descriptions contains only supported characters");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/CheckNumerous.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/CheckNumerous.java
@@ -35,7 +35,6 @@ public class CheckNumerous extends SingleDatabaseTestCase {
 
 	public CheckNumerous() {
 
-                addToGroup("variation-release");
 		setDescription("Check the database does not contain tables with columns with unexpectedly only one value");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionAlleles.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionAlleles.java
@@ -46,7 +46,6 @@ public class ComparePreviousVersionAlleles extends ComparePreviousVersionBase {
 	 */
 	public ComparePreviousVersionAlleles() {
 
-		addToGroup("variation-release");
 		setDescription("Compare the number of alleles in the current database with those from the equivalent database on the secondary server");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionConsequenceType.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionConsequenceType.java
@@ -53,7 +53,6 @@ public class ComparePreviousVersionConsequenceType extends ComparePreviousVersio
 	 */
 	public ComparePreviousVersionConsequenceType() {
 
-		addToGroup("variation-release");
 		
 		setDescription("Compare the number of transcript_variations having each consequence type status in the current database with those from the equivalent database on the secondary server");
 		setTeamResponsible(Team.VARIATION);

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionGenotypes.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionGenotypes.java
@@ -49,7 +49,6 @@ public class ComparePreviousVersionGenotypes extends ComparePreviousVersionBase 
 	 */
 	public ComparePreviousVersionGenotypes() {
 
-		addToGroup("variation-release");
 		setDescription("Compare the number of genotypes in the current database with those from the equivalent database on the secondary server");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionPhenotypeFeatures.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionPhenotypeFeatures.java
@@ -49,7 +49,6 @@ public class ComparePreviousVersionPhenotypeFeatures extends ComparePreviousVers
 	 */
 	public ComparePreviousVersionPhenotypeFeatures() {
 
-		addToGroup("variation-release");
 
 		setDescription("Compare the number of phenotype features in the current database with those from the equivalent database on the secondary server");
 		setTeamResponsible(Team.VARIATION);

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionReadCoverage.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionReadCoverage.java
@@ -45,7 +45,6 @@ public class ComparePreviousVersionReadCoverage extends ComparePreviousVersionBa
 	 * Create a new testcase.
 	 */
 	public ComparePreviousVersionReadCoverage() {
-		addToGroup("variation-release");
 		setDescription("Compare the number of reads for each sample with read coverage in the current database with those from the equivalent database on the secondary server");
 		setTeamResponsible(Team.VARIATION);
 	}

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionSampleDisplay.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionSampleDisplay.java
@@ -53,7 +53,6 @@ public class ComparePreviousVersionSampleDisplay extends ComparePreviousVersionB
 	 */
 	public ComparePreviousVersionSampleDisplay() {
 
-		addToGroup("variation-release");
 		setDescription("Compare the number of samples having each display value in the current database with those from the equivalent database on the secondary server");
     setTeamResponsible(Team.VARIATION);
 	}

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionSources.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionSources.java
@@ -46,7 +46,6 @@ public class ComparePreviousVersionSources extends ComparePreviousVersionBase {
 	 */
 	public ComparePreviousVersionSources() {
 
-		addToGroup("variation-release");
 		setDescription("Compare the number of variation sources in the current database with those from the equivalent database on the secondary server");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionStructuralVariations.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionStructuralVariations.java
@@ -49,7 +49,6 @@ public class ComparePreviousVersionStructuralVariations extends ComparePreviousV
 	 */
 	public ComparePreviousVersionStructuralVariations() {
 
-		addToGroup("variation-release");
 		setDescription("Compare the number of structural variations in the current database with those from the equivalent database on the secondary server");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionValidationStatus.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionValidationStatus.java
@@ -53,7 +53,6 @@ public class ComparePreviousVersionValidationStatus extends ComparePreviousVersi
 	 */
 	public ComparePreviousVersionValidationStatus() {
 
-		addToGroup("variation-release");
 		setDescription("Compare the number of variations having each an evidence annotation in the current database with those from the equivalent database on the secondary server");
                 setTeamResponsible(Team.VARIATION);
 	}

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionVariationClasses.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionVariationClasses.java
@@ -47,7 +47,6 @@ public class ComparePreviousVersionVariationClasses extends ComparePreviousVersi
 	 */
 	public ComparePreviousVersionVariationClasses() {
 
-		addToGroup("variation-release");
 		setDescription("Compare the number of variation classes in the current database with those from the equivalent database on the secondary server");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionVariationFeatures.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionVariationFeatures.java
@@ -47,7 +47,6 @@ public class ComparePreviousVersionVariationFeatures extends ComparePreviousVers
 	 */
 	public ComparePreviousVersionVariationFeatures() {
 
-		addToGroup("variation-release");
 		setDescription("Compare the number of variation features in the current database with those from the equivalent database on the secondary server");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionVariationSets.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionVariationSets.java
@@ -46,7 +46,6 @@ public class ComparePreviousVersionVariationSets extends ComparePreviousVersionB
 	 */
 	public ComparePreviousVersionVariationSets() {
 
-		addToGroup("variation-release");
 		setDescription("Compare the number of variation sets in the current database with those from the equivalent database on the secondary server");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionVariationSynonyms.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionVariationSynonyms.java
@@ -49,7 +49,6 @@ public class ComparePreviousVersionVariationSynonyms extends ComparePreviousVers
 	 */
 	public ComparePreviousVersionVariationSynonyms() {
 
-		addToGroup("variation-release");
 		setDescription("Compare the number of variation synonyms in the current database with those from the equivalent database on the secondary server");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionVariations.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ComparePreviousVersionVariations.java
@@ -49,7 +49,6 @@ public class ComparePreviousVersionVariations extends ComparePreviousVersionBase
 	 */
 	public ComparePreviousVersionVariations() {
 
-		addToGroup("variation-release");
 		setDescription("Compare the number of variations in the current database with those from the equivalent database on the secondary server");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/CompressedGenotypeRegion.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/CompressedGenotypeRegion.java
@@ -66,7 +66,6 @@ public class CompressedGenotypeRegion extends SingleDatabaseTestCase {
    */
   public CompressedGenotypeRegion() {
 
-    addToGroup("variation-release");
 
     setDescription("Checks that the compressed_genotype_region table is valid for the 1000 Genomes data");
 

--- a/src/org/ensembl/healthcheck/testcase/variation/Denormalized.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/Denormalized.java
@@ -38,7 +38,6 @@ public class Denormalized extends SingleDatabaseTestCase {
    */
   public Denormalized() {
 
-    addToGroup("variation-release");
     setDescription("Check for broken denormalization.");
     setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/EmptyVariationTables.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/EmptyVariationTables.java
@@ -49,7 +49,6 @@ public class EmptyVariationTables extends SingleDatabaseTestCase {
    */
   public EmptyVariationTables() {
 
-    addToGroup("variation-release");
 
     setDescription("Checks that all tables have data");
     setTeamResponsible(Team.VARIATION);

--- a/src/org/ensembl/healthcheck/testcase/variation/FlankingUpDownSeq.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/FlankingUpDownSeq.java
@@ -35,7 +35,6 @@ public class FlankingUpDownSeq extends SingleDatabaseTestCase {
 	 * Creates a new instance of CheckFlankingUpDownSeq
 	 */
 	public FlankingUpDownSeq() {
-		//addToGroup("variation-release");
 		setDescription("Check that if the up_seq or down_seq of flanking_sequence is null, that up_seq_region_start or down_seq_region_start should not be null.");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/ForeignKeyCoreId.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ForeignKeyCoreId.java
@@ -43,7 +43,6 @@ public class ForeignKeyCoreId extends MultiDatabaseTestCase {
 	 */
 	public ForeignKeyCoreId() {
 
-		addToGroup("variation-release");
 		setDescription("Check for broken foreign-key relationships between variation and core databases.");
 		setHintLongRunning(true);
 		setTeamResponsible(Team.VARIATION);

--- a/src/org/ensembl/healthcheck/testcase/variation/IndividualType.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/IndividualType.java
@@ -39,7 +39,6 @@ public class IndividualType extends SingleDatabaseTestCase {
 	 */
 	public IndividualType() {
 
-		addToGroup("variation-release");
 
 		setDescription("Check that the individuals have the correct type for each specie");
 		setTeamResponsible(Team.VARIATION);

--- a/src/org/ensembl/healthcheck/testcase/variation/Meta.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/Meta.java
@@ -38,7 +38,6 @@ public class Meta extends SingleDatabaseTestCase {
 	 */
 	public Meta() {
 
-		addToGroup("variation-release");
 		setDescription("Check that the meta table contains the right entries for the human and mouse");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/Meta_coord.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/Meta_coord.java
@@ -37,7 +37,6 @@ public class Meta_coord extends SingleDatabaseTestCase {
 	 */
 	public Meta_coord() {
 
-		addToGroup("variation-release");
 		setDescription("Check that the meta_coord table contains the right entries for the different variation species");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/Phenotype.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/Phenotype.java
@@ -49,7 +49,6 @@ public class Phenotype extends SingleDatabaseTestCase {
 	 */
 	public Phenotype() {
 
-		addToGroup("variation-release");
 		
 		setDescription("Checks that the phenotype table does not have empty descriptions");
 		setTeamResponsible(Team.VARIATION);

--- a/src/org/ensembl/healthcheck/testcase/variation/Population.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/Population.java
@@ -38,7 +38,6 @@ public class Population extends SingleDatabaseTestCase {
 	 * Creates a new instance of Population
 	 */
 	public Population() {
-		addToGroup("variation-release");
 		setDescription("Check the Populations are entered as expected");
 		setTeamResponsible(Team.VARIATION);
 	}

--- a/src/org/ensembl/healthcheck/testcase/variation/PopulationGenotype.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/PopulationGenotype.java
@@ -38,7 +38,6 @@ public class PopulationGenotype extends SingleDatabaseTestCase {
 	 * Creates a new instance of PopulationGenotype
 	 */
 	public PopulationGenotype() {
-	//	addToGroup("variation-release");
 		setDescription("Check the two PopulationGenotype tables have the same populations");
 		setTeamResponsible(Team.VARIATION);
 	}

--- a/src/org/ensembl/healthcheck/testcase/variation/Publication.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/Publication.java
@@ -38,7 +38,6 @@ public class Publication extends SingleDatabaseTestCase {
 	 */
 	public Publication() {
 
-		addToGroup("variation-release");
 		setDescription("Check the database does not contain duplicated Publication entries");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/Source.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/Source.java
@@ -33,7 +33,6 @@ public class Source extends SingleDatabaseTestCase {
 
 	public Source() {
 
-		addToGroup("variation-release");
 		
 		setDescription("Checks that the soucre table is consistent");
 		setTeamResponsible(Team.VARIATION);

--- a/src/org/ensembl/healthcheck/testcase/variation/StructuralVariation.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/StructuralVariation.java
@@ -49,7 +49,6 @@ public class StructuralVariation extends SingleDatabaseTestCase {
 	 */
 	public StructuralVariation() {
 
-		addToGroup("variation-release");
 		
 		setDescription("Checks that the structural variation tables make sense");
 		setTeamResponsible(Team.VARIATION);

--- a/src/org/ensembl/healthcheck/testcase/variation/TranscriptVariation.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/TranscriptVariation.java
@@ -39,7 +39,6 @@ public class TranscriptVariation extends SingleDatabaseTestCase {
      * Creates a new instance of Check Transcript Variation
      */
     public TranscriptVariation() {
-    	addToGroup("variation-release");
         setDescription("Check that if the peptide_allele_string of transcript_variation is not >1. It should out >1, unless it filled with numbers");
 		setTeamResponsible(Team.VARIATION);
     }

--- a/src/org/ensembl/healthcheck/testcase/variation/VFCoordinates.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/VFCoordinates.java
@@ -41,8 +41,6 @@ public class VFCoordinates extends MultiDatabaseTestCase {
 	 */
 	public VFCoordinates() {
 
-		/*
-		*/
 		setDescription("Check for possible wrong coordinates in Vf table, due to wrong length or outside range seq_region.");
 		// setHintLongRunning(true);
 		setTeamResponsible(Team.VARIATION);

--- a/src/org/ensembl/healthcheck/testcase/variation/VFCoordinates.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/VFCoordinates.java
@@ -42,7 +42,6 @@ public class VFCoordinates extends MultiDatabaseTestCase {
 	public VFCoordinates() {
 
 		/*
-		addToGroup("variation-release");
 		*/
 		setDescription("Check for possible wrong coordinates in Vf table, due to wrong length or outside range seq_region.");
 		// setHintLongRunning(true);

--- a/src/org/ensembl/healthcheck/testcase/variation/Variation.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/Variation.java
@@ -49,7 +49,6 @@ public class Variation extends SingleDatabaseTestCase {
 	 */
 	public Variation() {
 
-		addToGroup("variation-release");
 		
 		setDescription("Checks the variation table");
 		setTeamResponsible(Team.VARIATION);

--- a/src/org/ensembl/healthcheck/testcase/variation/VariationClasses.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/VariationClasses.java
@@ -50,7 +50,6 @@ public class VariationClasses extends SingleDatabaseTestCase {
 	 */
 	public VariationClasses() {
 
-		addToGroup("variation-release");
 
 		setDescription("Sanity check variation classes");
 		setTeamResponsible(Team.VARIATION);

--- a/src/org/ensembl/healthcheck/testcase/variation/VariationFeature.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/VariationFeature.java
@@ -50,7 +50,6 @@ public class VariationFeature extends SingleDatabaseTestCase {
 	 */
 	public VariationFeature() {
 
-		addToGroup("variation-release");
 		
 		setDescription("Checks that the variation_feature table makes sense");
 		setTeamResponsible(Team.VARIATION);

--- a/src/org/ensembl/healthcheck/testcase/variation/VariationFeatureAlleles.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/VariationFeatureAlleles.java
@@ -33,7 +33,6 @@ public class VariationFeatureAlleles extends SingleDatabaseTestCase {
      */
     public VariationFeatureAlleles() {
 
-        addToGroup("variation-release");
         setDescription("Check for variation features with no alleles.");
         setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/VariationForeignKeys.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/VariationForeignKeys.java
@@ -37,7 +37,6 @@ public class VariationForeignKeys extends SingleDatabaseTestCase {
 	 */
 	public VariationForeignKeys() {
 
-		addToGroup("variation-release");
 		setDescription("Check for broken foreign-key relationships.");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testcase/variation/VariationSet.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/VariationSet.java
@@ -58,7 +58,6 @@ public class VariationSet extends SingleDatabaseTestCase {
 	 */
 	public VariationSet() {
 
-		addToGroup("variation-release");
 
 		setDescription("Checks that the variation_set tables are valid");
 

--- a/src/org/ensembl/healthcheck/testcase/variation/VariationSynonym.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/VariationSynonym.java
@@ -36,7 +36,6 @@ public class VariationSynonym extends SingleDatabaseTestCase {
 	 * Creates a new instance of Check Variation Synonym
 	 */
 	public VariationSynonym() {
-		addToGroup("variation-release");
 		setDescription("Check for duplicate variation synonyms");
 		setTeamResponsible(Team.VARIATION);
 

--- a/src/org/ensembl/healthcheck/testgroup/VariationPreHandover.java
+++ b/src/org/ensembl/healthcheck/testgroup/VariationPreHandover.java
@@ -33,6 +33,7 @@ import org.ensembl.healthcheck.GroupOfTests;
  *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionSources </li>
  *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionStructuralVariations </li>
  *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionValidationStatus </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationClasses </li>
  *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationFeatures </li>
  *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationSets </li>
  *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationSynonyms </li>
@@ -55,13 +56,14 @@ import org.ensembl.healthcheck.GroupOfTests;
  *   <li> org.ensembl.healthcheck.testcase.variation.VariationClasses </li>
  *   <li> org.ensembl.healthcheck.testcase.variation.VariationFeature </li>
  *   <li> org.ensembl.healthcheck.testcase.variation.VariationForeignKeys </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.VariationFeatureAlleles </li>
  *   <li> org.ensembl.healthcheck.testcase.variation.VariationSet </li>
  *   <li> org.ensembl.healthcheck.testcase.variation.VariationSynonym </li>
  *   <li> org.ensembl.healthcheck.testcase.generic.MySQLStorageEngine </li>
  *   <li> org.ensembl.healthcheck.testcase.generic.SchemaType </li>
  * </ul>
  *
- * @author Thomas Maurel
+ * @author Helen Schuilenburg
  *
  */
 public class VariationPreHandover extends GroupOfTests {

--- a/src/org/ensembl/healthcheck/testgroup/VariationPreHandover.java
+++ b/src/org/ensembl/healthcheck/testgroup/VariationPreHandover.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+ * Copyright [2016-2018] EMBL-European Bioinformatics Institute
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ensembl.healthcheck.testgroup;
+
+import org.ensembl.healthcheck.GroupOfTests;
+
+/**
+ * These are the tests that run before handover to production. The tests are:
+ * 
+ * <ul>
+ *   <li> org.ensembl.healthcheck.testcase.variation.CheckChar </li> 
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionAlleles </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionConsequenceType </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionGenotypes </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionPhenotypeFeatures </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionReadCoverage </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionSampleDisplay </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionSources </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionStructuralVariations </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionValidationStatus </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationFeatures </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationSets </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationSynonyms </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariations </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.CompareVariationSchema </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.CompressedGenotypeRegion </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.Denormalized </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.EmptyVariationTables </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.ForeignKeyCoreId </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.IndividualType </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.Meta </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.Meta_coord </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.Phenotype </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.PhenotypeFeatureAttrib </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.Population </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.Publication </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.StructuralVariation </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.TranscriptVariation </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.Variation </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.VariationClasses </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.VariationFeature </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.VariationForeignKeys </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.VariationSet </li>
+ *   <li> org.ensembl.healthcheck.testcase.variation.VariationSynonym </li>
+ *   <li> org.ensembl.healthcheck.testcase.generic.MySQLStorageEngine </li>
+ *   <li> org.ensembl.healthcheck.testcase.generic.SchemaType </li>
+ * </ul>
+ *
+ * @author Thomas Maurel
+ *
+ */
+public class VariationPreHandover extends GroupOfTests {
+	
+	public VariationPreHandover() {
+
+		addTest(
+			org.ensembl.healthcheck.testcase.variation.CheckChar.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionAlleles.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionConsequenceType.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionGenotypes.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionPhenotypeFeatures.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionReadCoverage.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionSampleDisplay.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionSources.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionStructuralVariations.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionValidationStatus.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationClasses.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationFeatures.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationSets.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationSynonyms.class,
+			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariations.class,
+			org.ensembl.healthcheck.testcase.variation.CompareVariationSchema.class,
+			org.ensembl.healthcheck.testcase.variation.CompressedGenotypeRegion.class,
+			org.ensembl.healthcheck.testcase.variation.Denormalized.class,
+			org.ensembl.healthcheck.testcase.variation.EmptyVariationTables.class,
+			org.ensembl.healthcheck.testcase.variation.ForeignKeyCoreId.class,
+			org.ensembl.healthcheck.testcase.variation.IndividualType.class,
+			org.ensembl.healthcheck.testcase.variation.Meta.class,
+			org.ensembl.healthcheck.testcase.variation.Meta_coord.class,
+			org.ensembl.healthcheck.testcase.variation.Phenotype.class,
+			org.ensembl.healthcheck.testcase.variation.PhenotypeFeatureAttrib.class,
+			org.ensembl.healthcheck.testcase.variation.Population.class,
+			org.ensembl.healthcheck.testcase.variation.Publication.class,
+			org.ensembl.healthcheck.testcase.variation.StructuralVariation.class,
+			org.ensembl.healthcheck.testcase.variation.TranscriptVariation.class,
+			org.ensembl.healthcheck.testcase.variation.Variation.class,
+			org.ensembl.healthcheck.testcase.variation.VariationClasses.class,
+			org.ensembl.healthcheck.testcase.variation.VariationFeature.class,
+			org.ensembl.healthcheck.testcase.variation.VariationForeignKeys.class,
+      org.ensembl.healthcheck.testcase.variation.VariationFeatureAlleles.class,
+			org.ensembl.healthcheck.testcase.variation.VariationSet.class,
+			org.ensembl.healthcheck.testcase.variation.VariationSynonym.class,
+      org.ensembl.healthcheck.testcase.generic.MySQLStorageEngine.class,
+      org.ensembl.healthcheck.testcase.generic.SchemaType.class
+		);
+	}
+}

--- a/src/org/ensembl/healthcheck/testgroup/VariationRelease.java
+++ b/src/org/ensembl/healthcheck/testgroup/VariationRelease.java
@@ -20,43 +20,11 @@ package org.ensembl.healthcheck.testgroup;
 import org.ensembl.healthcheck.GroupOfTests;
 
 /**
- * These are the tests that register themselves as variation-release. The tests are:
+ * These are the tests that run after handover to production. The tests are:
  * 
  * <ul>
- *   <li> org.ensembl.healthcheck.testcase.variation.CheckChar </li> 
- *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionAlleles </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionConsequenceType </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionGenotypes </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionPhenotypeFeatures </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionReadCoverage </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionSampleDisplay </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionSources </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionStructuralVariations </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionValidationStatus </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationFeatures </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationSets </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationSynonyms </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariations </li>
  *   <li> org.ensembl.healthcheck.testcase.variation.CompareVariationSchema </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.CompressedGenotypeRegion </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.Denormalized </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.EmptyVariationTables </li>
  *   <li> org.ensembl.healthcheck.testcase.variation.ForeignKeyCoreId </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.IndividualType </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.Meta </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.Meta_coord </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.Phenotype </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.PhenotypeFeatureAttrib </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.Population </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.Publication </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.StructuralVariation </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.TranscriptVariation </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.Variation </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.VariationClasses </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.VariationFeature </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.VariationForeignKeys </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.VariationSet </li>
- *   <li> org.ensembl.healthcheck.testcase.variation.VariationSynonym </li>
  *   <li> org.ensembl.healthcheck.testcase.generic.MySQLStorageEngine </li>
  *   <li> org.ensembl.healthcheck.testcase.generic.SchemaType </li>
  * </ul>
@@ -69,42 +37,8 @@ public class VariationRelease extends GroupOfTests {
 	public VariationRelease() {
 
 		addTest(
-			org.ensembl.healthcheck.testcase.variation.CheckChar.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionAlleles.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionConsequenceType.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionGenotypes.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionPhenotypeFeatures.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionReadCoverage.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionSampleDisplay.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionSources.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionStructuralVariations.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionValidationStatus.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationClasses.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationFeatures.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationSets.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariationSynonyms.class,
-			org.ensembl.healthcheck.testcase.variation.ComparePreviousVersionVariations.class,
 			org.ensembl.healthcheck.testcase.variation.CompareVariationSchema.class,
-			org.ensembl.healthcheck.testcase.variation.CompressedGenotypeRegion.class,
-			org.ensembl.healthcheck.testcase.variation.Denormalized.class,
-			org.ensembl.healthcheck.testcase.variation.EmptyVariationTables.class,
 			org.ensembl.healthcheck.testcase.variation.ForeignKeyCoreId.class,
-			org.ensembl.healthcheck.testcase.variation.IndividualType.class,
-			org.ensembl.healthcheck.testcase.variation.Meta.class,
-			org.ensembl.healthcheck.testcase.variation.Meta_coord.class,
-			org.ensembl.healthcheck.testcase.variation.Phenotype.class,
-			org.ensembl.healthcheck.testcase.variation.PhenotypeFeatureAttrib.class,
-			org.ensembl.healthcheck.testcase.variation.Population.class,
-			org.ensembl.healthcheck.testcase.variation.Publication.class,
-			org.ensembl.healthcheck.testcase.variation.StructuralVariation.class,
-			org.ensembl.healthcheck.testcase.variation.TranscriptVariation.class,
-			org.ensembl.healthcheck.testcase.variation.Variation.class,
-			org.ensembl.healthcheck.testcase.variation.VariationClasses.class,
-			org.ensembl.healthcheck.testcase.variation.VariationFeature.class,
-			org.ensembl.healthcheck.testcase.variation.VariationForeignKeys.class,
-      org.ensembl.healthcheck.testcase.variation.VariationFeatureAlleles.class,
-			org.ensembl.healthcheck.testcase.variation.VariationSet.class,
-			org.ensembl.healthcheck.testcase.variation.VariationSynonym.class,
       org.ensembl.healthcheck.testcase.generic.MySQLStorageEngine.class,
       org.ensembl.healthcheck.testcase.generic.SchemaType.class
 		);


### PR DESCRIPTION
VariationPreHandover.java group created  to containe pre handover checks based on VariationRelease.java (JIRA: ENSVAR-954)

VariationRelease.java modified to contain only variation testcases:
    CompareVariationSchema
    ForeignKeyCoreId

and generic testcases:
    MySQLStorageEngine
    SchemaType

addToGroup has been deprecated, so removed from all testcases in healthcheck/testcase/variation

Need to review if
- generic test cases be part of VariationRelease
- CheckNumerous.java, Source.java should be run
- VFCoordinates.java, PopulationGenotype.java be marked for removal

