### PR TITLE
Use standard modules for schema comparison

### DIFF
--- a/src/org/ensembl/healthcheck/testgroup/EGCoreGeneModelCritical.java
+++ b/src/org/ensembl/healthcheck/testgroup/EGCoreGeneModelCritical.java
@@ -20,7 +20,6 @@ package org.ensembl.healthcheck.testgroup;
 import org.ensembl.healthcheck.GroupOfTests;
 import org.ensembl.healthcheck.testcase.eg_core.CircularAwareFeatureCoords;
 import org.ensembl.healthcheck.testcase.eg_core.DuplicateTopLevel;
-import org.ensembl.healthcheck.testcase.eg_core.EGCompareCoreSchema;
 import org.ensembl.healthcheck.testcase.eg_core.ENASeqRegionSynonyms;
 import org.ensembl.healthcheck.testcase.eg_core.EnaSeqRegionName;
 import org.ensembl.healthcheck.testcase.eg_core.MultipleENASeqRegionSynonyms;
@@ -71,7 +70,6 @@ public class EGCoreGeneModelCritical extends GroupOfTests {
 			AssemblySeqregion.class, 
 			CanonicalTranscriptCoding.class,
 			CircularAwareFeatureCoords.class, 
-			EGCompareCoreSchema.class,
 			CoreForeignKeys.class,
 			DuplicateAssembly.class, 
 			DuplicateTopLevel.class,

--- a/src/org/ensembl/healthcheck/testgroup/EGVariation.java
+++ b/src/org/ensembl/healthcheck/testgroup/EGVariation.java
@@ -18,7 +18,6 @@
 package org.ensembl.healthcheck.testgroup;
 
 import org.ensembl.healthcheck.GroupOfTests;
-import org.ensembl.healthcheck.testcase.eg_core.EGCompareVariationSchema;
 import org.ensembl.healthcheck.testcase.eg_variation.EGVariationFeature;
 import org.ensembl.healthcheck.testcase.variation.AlleleFrequencies;
 import org.ensembl.healthcheck.testcase.variation.CompareVariationSchema;
@@ -46,7 +45,7 @@ public class EGVariation extends GroupOfTests {
 		addTest(
 			EGCommon.class,
 			AlleleFrequencies.class,
-			EGCompareVariationSchema.class,
+			CompareVariationSchema.class,
 			EGVariationFeature.class,
 			EmptyVariationTables.class, 
 			ForeignKeyCoreId.class, 


### PR DESCRIPTION
The EG schema comparison tests offer a small amount of additional functionality compared to the standard Ensembl ones, but they get foxed by checksum properties being defined on tables, and require a non-standard perl library; it's not worth maintaining them.