### PR TITLE
making HC circular safe

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/generic/SubCodonTranscript.java
+++ b/src/org/ensembl/healthcheck/testcase/generic/SubCodonTranscript.java
@@ -44,7 +44,7 @@ public class SubCodonTranscript extends AbstractRowCountTestCase {
 	}
 
 	private final static String QUERY = "select count(*) from transcript "
-	        + "where biotype='protein_coding' and abs(seq_region_end-seq_region_start)<2";
+	        + "where biotype='protein_coding' and abs(CAST(seq_region_end AS SIGNED)-CAST(seq_region_start AS SIGNED))<2";
 
 	/*
 	 * (non-Javadoc)


### PR DESCRIPTION
Not 100% sure this maintains the original intent of the HC, but I think it does.

Without this the query dies:
ERROR 1690 (22003): BIGINT UNSIGNED value is out of range in '(`hordeum_vulgare_core_38_91_3`.`transcript`.`seq_region_end` - `hordeum_vulgare_core_38_91_3`.`transcript`.`seq_region_start`)'
