### PR TITLE
stop a missing meta_key causing a null pointer exception

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/funcgen/AbstractCoreDatabaseUsingTestCase.java
+++ b/src/org/ensembl/healthcheck/testcase/funcgen/AbstractCoreDatabaseUsingTestCase.java
@@ -33,8 +33,13 @@ public abstract class AbstractCoreDatabaseUsingTestCase extends SingleDatabaseTe
 		try {
 			Statement stmt = coreConnection.createStatement();
 			ResultSet rs = stmt.executeQuery(sql);
-			rs.next();
-			metaValue = rs.getString("meta_value");
+			if(rs.next()){
+                            metaValue = rs.getString("meta_value");
+                        }
+                        else{
+                            return null;
+                        }
+
 		} catch (SQLException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
surely this could be more elegant, but this fix at least allows the HC to fail gracefully rather than die with a null pointer exception