### PR TITLE
remove GO from xref sources

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/generic/ComparePreviousVersionXrefs.java
+++ b/src/org/ensembl/healthcheck/testcase/generic/ComparePreviousVersionXrefs.java
@@ -63,7 +63,7 @@ public class ComparePreviousVersionXrefs extends ComparePreviousVersionBase {
 
 	protected Map<String, Integer> getCounts(DatabaseRegistryEntry dbre) {
 
-		String sql = "SELECT DISTINCT(e.db_name) AS db_name, COUNT(*) AS count" + " FROM external_db e, xref x, object_xref ox" + " WHERE e.external_db_id=x.external_db_id AND x.xref_id=ox.xref_id "
+		String sql = "SELECT DISTINCT(e.db_name) AS db_name, COUNT(*) AS count" + " FROM external_db e, xref x, object_xref ox" + " WHERE e.external_db_id=x.external_db_id AND x.xref_id=ox.xref_id AND e.db_name not like 'GO' "
 				+ getExcludeProjectedSQL(dbre) + " GROUP BY e.db_name";
 		// System.out.println(sql);
 		return getCountsBySQL(dbre, sql);


### PR DESCRIPTION
The ComparePreviousVersionXrefs HC compare xrefs by sources between the last release and the latest updated set. At the time the xref pipeline is run, there are no GO xrefs, because they are added by a separate pipeline later in the release. This means that the ComparePreviousVersionXrefs HC fails for all species because there are no GO xrefs, which we do not expect at this stage. 
The SQL query has been updated to ignore xrefs of source GO, meaning they can check the sources that have effectively been updated when running the xref pipeline.
GO import is tested separately by other HC, in particular the GOXref HC