### PR TITLE
As of MySQL 5.5.5, overflow during numeric expression evaluation resu…

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/generic/TranslationCheckSeqStart.java
+++ b/src/org/ensembl/healthcheck/testcase/generic/TranslationCheckSeqStart.java
@@ -74,8 +74,8 @@ public class TranslationCheckSeqStart extends SingleDatabaseTestCase {
 		//Get the seq_region_start from exon tables and check if translation seq_start is greater than start exon's length
 		
 		String sql = "SELECT t.*,exon_start.exon_id,exon_start.seq_region_strand , exon_start.seq_region_end, exon_start.seq_region_start,"
-				+ "exon_start.seq_region_end - exon_start.seq_region_start + 1 as exon_start_length,exon_end.exon_id,exon_end.seq_region_strand, exon_end.seq_region_end, exon_end.seq_region_start, "
-				+ "exon_end.seq_region_end - exon_end.seq_region_start+1 as exon_end_length "
+				+ "cast(exon_start.seq_region_end as signed) - cast(exon_start.seq_region_start as signed) + 1 as exon_start_length,exon_end.exon_id,exon_end.seq_region_strand, exon_end.seq_region_end, exon_end.seq_region_start, "
+				+ "cast(exon_end.seq_region_end as signed) - cast(exon_end.seq_region_start as signed) +1 as exon_end_length "
 				+ "FROM translation t "
 				+ "INNER JOIN exon exon_start on t.start_exon_id = exon_start.exon_id "
 				+ "INNER JOIN exon exon_end on t.end_exon_id=exon_end.exon_id "

--- a/src/org/ensembl/healthcheck/testcase/generic/TranslationCheckZeroLength.java
+++ b/src/org/ensembl/healthcheck/testcase/generic/TranslationCheckZeroLength.java
@@ -77,7 +77,7 @@ public class TranslationCheckZeroLength extends SingleDatabaseTestCase {
 				+ "exon_end.exon_id,exon_end.seq_region_strand,exon_end.seq_region_start as exon_end_seq_start,exon_end.seq_region_end as exon_end_seq_end,"
 				+ "IF(exon_end.seq_region_strand>0,exon_end.seq_region_start+t.seq_end-1,exon_start.seq_region_end-t.seq_start+1) as cds_end, "
 				+ "IF(exon_start.seq_region_strand>0,exon_start.seq_region_start+t.seq_start-1,exon_end.seq_region_end-t.seq_end+1) as cds_start, "
-				+ "(IF(exon_end.seq_region_strand>0,exon_end.seq_region_start+t.seq_end-1,exon_start.seq_region_end-t.seq_start+1)  - IF(exon_start.seq_region_strand>0,exon_start.seq_region_start+t.seq_start-1,exon_end.seq_region_end-t.seq_end+1)+1) as cds_length "
+				+ "(IF(exon_end.seq_region_strand>0,exon_end.seq_region_start+t.seq_end-1,exon_start.seq_region_end-t.seq_start+1)  - IF(exon_start.seq_region_strand>0,exon_start.seq_region_start+t.seq_start-1,cast(exon_end.seq_region_end as signed)-t.seq_end+1)+1) as cds_length "
 				+ "FROM translation t "
 				+ "INNER JOIN exon exon_start on t.start_exon_id = exon_start.exon_id "
 				+ "INNER JOIN exon exon_end on t.end_exon_id=exon_end.exon_id "


### PR DESCRIPTION
…lts in an error. Both queries return the following error: Data truncation: BIGINT UNSIGNED value is out of range in (exon_start.seq_region_end - exon_start.seq_region_start), see JIRA ticket ENSPROD-2105 for details. setting the column as signed increased the maximum value and stop the overflow.