### PR TITLE
ENSCORESW-2834: remove ancient schema check

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/generic/ComparePreviousVersionXrefs.java
+++ b/src/org/ensembl/healthcheck/testcase/generic/ComparePreviousVersionXrefs.java
@@ -96,12 +96,7 @@ public class ComparePreviousVersionXrefs extends ComparePreviousVersionBase {
 
 	private String getExcludeProjectedSQL(DatabaseRegistryEntry dbre) {
 
-		String sql = "";
-		if (dbre.getSchemaVersion() == null) { // guess if we can't get the schema version
-			sql = " AND (x.info_type != 'PROJECTION' OR x.info_type IS NULL)";
-		} else {
-			sql = Integer.parseInt(dbre.getSchemaVersion()) <= 37 ? " AND x.display_label NOT LIKE '%[from%'" : " AND (x.info_type != 'PROJECTION' OR x.info_type IS NULL)";
-		}
+		String sql = " AND (x.info_type != 'PROJECTION' OR x.info_type IS NULL)";
 
 		return sql;
 


### PR DESCRIPTION
This was breaking HCs for non-vertebrates where the schema version is not so easy to guess.
As HCs should be run on recent databases, we assume that none is still on schema 37 or prior, so the additional schema check is not needed.
This makes the HC easier to maintain, compatible with more core databases and simpler to understand.
Tested on homo_sapiens_core_94_38 and drosophila_melanogaster_core_41_94_7