### PR TITLE
remove HCs from FuncgenIntegrity testgroup

### DIFF
--- a/src/org/ensembl/healthcheck/testgroup/FuncgenIntegrity.java
+++ b/src/org/ensembl/healthcheck/testgroup/FuncgenIntegrity.java
@@ -19,6 +19,12 @@ Cheers,
 < your name >
 
 */
+
+/* TODO 
+"ExperimentHasFeatureSet" has been disabled temporarily.
+It reports minor data errors that are true but won't be fixed for now.
+We might reinstate it in the future.
+*/
   public FuncgenIntegrity() {
 
       addTest(
@@ -27,6 +33,7 @@ Cheers,
         org.ensembl.healthcheck.testcase.funcgen.CompareFuncgenSchema.class,
         org.ensembl.healthcheck.testcase.funcgen.CurrentRegulatoryBuildHasEpigenomes.class,
         org.ensembl.healthcheck.testcase.funcgen.EpigenomeHasSegmentationFile.class,
+        // org.ensembl.healthcheck.testcase.funcgen.ExperimentHasFeatureSet.class,
         org.ensembl.healthcheck.testcase.funcgen.ExternalFeatureFilesExist.class,
         org.ensembl.healthcheck.testcase.funcgen.FeaturePosition.class,
         org.ensembl.healthcheck.testcase.funcgen.FuncgenAnalysisDescription.class,

--- a/src/org/ensembl/healthcheck/testgroup/FuncgenIntegrity.java
+++ b/src/org/ensembl/healthcheck/testgroup/FuncgenIntegrity.java
@@ -22,13 +22,11 @@ Cheers,
   public FuncgenIntegrity() {
 
       addTest(
-        org.ensembl.healthcheck.testcase.funcgen.AlignmentHasBamFile.class,
         org.ensembl.healthcheck.testcase.funcgen.ArraysHaveProbes.class,
         org.ensembl.healthcheck.testcase.funcgen.BrokenFeatureSetToFeatureTypeLinks.class,
         org.ensembl.healthcheck.testcase.funcgen.CompareFuncgenSchema.class,
         org.ensembl.healthcheck.testcase.funcgen.CurrentRegulatoryBuildHasEpigenomes.class,
         org.ensembl.healthcheck.testcase.funcgen.EpigenomeHasSegmentationFile.class,
-        org.ensembl.healthcheck.testcase.funcgen.ExperimentHasFeatureSet.class,
         org.ensembl.healthcheck.testcase.funcgen.ExternalFeatureFilesExist.class,
         org.ensembl.healthcheck.testcase.funcgen.FeaturePosition.class,
         org.ensembl.healthcheck.testcase.funcgen.FuncgenAnalysisDescription.class,


### PR DESCRIPTION
Two HCs removed from FuncgenIntegrity testgroup:
-"AlignmentHasBamFile" was included accidentally.
-"ExperimentHasFeatureSet" has been removed temporarily. It reports minor data errors that are true but won't be fixed for now. We might reinstate it in the future.
