### PR TITLE
Removing InterproFeatures from GenebuildPostHandover as databases can…

### DIFF
--- a/src/org/ensembl/healthcheck/testgroup/EGCoreHandoverService.java
+++ b/src/org/ensembl/healthcheck/testgroup/EGCoreHandoverService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright [1999-2018] EMBL-European Bioinformatics Institute
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ensembl.healthcheck.testgroup;
+
+import org.ensembl.healthcheck.testcase.generic.ProductionMasterTables;
+/**
+ * @author tmaurel
+ *
+ */
+public class EGCoreHandoverService extends EGCoreHandover {
+
+	/**
+	 * 
+	 */
+	public EGCoreHandoverService() {
+		super();
+		this.removeTest(ProductionMasterTables.class);
+	}
+
+}

--- a/src/org/ensembl/healthcheck/testgroup/GenebuildPostHandover.java
+++ b/src/org/ensembl/healthcheck/testgroup/GenebuildPostHandover.java
@@ -40,7 +40,6 @@ public class GenebuildPostHandover extends GroupOfTests {
       org.ensembl.healthcheck.testcase.generic.ExonStrandOrder.class,
       org.ensembl.healthcheck.testcase.generic.ExonTranscriptStartEnd.class,
       org.ensembl.healthcheck.testcase.generic.GeneTranscriptStartEnd.class,
-      org.ensembl.healthcheck.testcase.generic.InterproFeatures.class,
       org.ensembl.healthcheck.testcase.generic.Karyotype.class,
       org.ensembl.healthcheck.testcase.generic.MTCodonTable.class,
       org.ensembl.healthcheck.testcase.generic.NullTranscripts.class,

--- a/src/org/ensembl/healthcheck/testgroup/GenebuildPostHandoverService.java
+++ b/src/org/ensembl/healthcheck/testgroup/GenebuildPostHandoverService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+ * Copyright [2016-2018] EMBL-European Bioinformatics Institute
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ensembl.healthcheck.testgroup;
+
+import org.ensembl.healthcheck.testcase.generic.EmptyTables;
+
+/**
+ * These are the critical checks to run once Genebuild have handed over the core
+ * databases.
+ */
+public class GenebuildPostHandoverService extends GenebuildPostHandover {
+
+  public GenebuildPostHandoverService() {
+    this.removeTest(EmptyTables.class);
+  }
+}


### PR DESCRIPTION
… be handed over without it. Created two new group for the handover service excluding test that can fail but are not critical. Empty table consistently fail in GenebuildPostHandover and ProductionMaster too in EGCoreHandover