### PR TITLE
Updated vertebrate division shortname from ens to EV to match changes…

### DIFF
--- a/run_ens_hive.sh
+++ b/run_ens_hive.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 # Script for healthcheck execution with locking
 
-div='ens'
+div='EV'
 
 function msg {
     echo $(date +"%Y-%m-%d %H:%M:%S") $1


### PR DESCRIPTION
… in release 95
Porting to master.