### PR TITLE
use stable_id in motif_feature table for FK test

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/variation/ForeignKeyFuncgenId.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ForeignKeyFuncgenId.java
@@ -92,7 +92,7 @@ public class ForeignKeyFuncgenId extends MultiDatabaseTestCase {
 
                         result &= checkForOrphans(con, dbvar.getName()
                                         + ".motif_feature_variation", "feature_stable_id",
-                                dbrfuncgen.getName() + ".regulatory_feature", "stable_id");
+                                dbrfuncgen.getName() + ".motif_feature", "stable_id");
 
                         result &= checkForOrphans(con, dbvar.getName()
                                         + ".regulatory_feature_variation", "feature_stable_id",


### PR DESCRIPTION
Funcgen team added stable ids for motif features. we can can now use those for the foreign key test instead of using associated regulatory feature stable ids.
Resubmitting https://github.com/Ensembl/ensj-healthcheck/pull/117 which couldn't make it into 95 branch due to some timing conflicts. @helensch could you please check the PR? Thanks