### PR TITLE
transcript_variation is not needed in meta_coord table

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/variation/Meta_coord.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/Meta_coord.java
@@ -53,7 +53,7 @@ public class Meta_coord extends SingleDatabaseTestCase {
 		boolean result = true;
 
 		Connection con = dbre.getConnection();
-		String[] tables = { "variation_feature", "compressed_genotype_region", "transcript_variation", "structural_variation_feature", "read_coverage", "phenotype_feature" };
+		String[] tables = { "variation_feature", "compressed_genotype_region", "structural_variation_feature", "read_coverage", "phenotype_feature" };
 		
 		try {
 			/*


### PR DESCRIPTION
We don't need the transcript_variation entry in the meta_coord table. We remove the table from the Meta_coord HC.