### PR TITLE
Added ControlledComparaTables to the set

### DIFF
--- a/src/org/ensembl/healthcheck/testgroup/ComparaAll.java
+++ b/src/org/ensembl/healthcheck/testgroup/ComparaAll.java
@@ -32,6 +32,7 @@ public class ComparaAll extends GroupOfTests {
 			org.ensembl.healthcheck.testgroup.ComparaGenomicOnly.class,
 			org.ensembl.healthcheck.testgroup.ComparaHomologyOnly.class,
 			org.ensembl.healthcheck.testgroup.ComparaReleaseOnly.class,
+			org.ensembl.healthcheck.testgroup.ControlledComparaTables.class,
 			org.ensembl.healthcheck.testgroup.ComparaShared.class
 		);
 	}


### PR DESCRIPTION
Whilst working on our relco SOP I've realized that `ComparaAll` doesn't really contain everything, and is missing `ControlledComparaTables`.
PS: in practice, we often break down ComparaAll and run the subgroups in parallel anyway, but at least ComparaAll should really be "All"