### PR TITLE
Improved performance by additional flag and merged queries

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/compara/CheckConservationScorePerBlock.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/CheckConservationScorePerBlock.java
@@ -19,6 +19,7 @@
 package org.ensembl.healthcheck.testcase.compara;
 
 import java.sql.Connection;
+import java.util.List;
 
 import org.ensembl.healthcheck.DatabaseRegistryEntry;
 import org.ensembl.healthcheck.ReportManager;
@@ -56,38 +57,42 @@ public class CheckConservationScorePerBlock extends SingleDatabaseTestCase {
 		Connection con = dbre.getConnection();
 
 		/**
-		 * Get all method_link_species_set_ids for method_link type of
-		 * GERP_CONSERVATION_SCORE
-		 */
-		String[] method_link_species_set_ids = DBUtils.getColumnValues(con, "SELECT method_link_species_set_id FROM method_link_species_set LEFT JOIN method_link USING (method_link_id) WHERE type=\"GERP_CONSERVATION_SCORE\" OR class LIKE \"ConservationScore%\"");
-
-		/**
 		 * Get Ancestral sequences genome_db_id
 		 */
 		String ancestral_seq_id = DBUtils.getRowColumnValue(con, "SELECT genome_db_id FROM genome_db WHERE name = \"ancestral_sequences\"");
 
-		if (method_link_species_set_ids.length > 0) {
-
-			for(String mlss_id : method_link_species_set_ids) {
-
-				// Get the mlss_id for the associated multiple alignment
-				String multi_align_mlss_id = DBUtils.getRowColumnValue(con, "SELECT value FROM method_link_species_set_tag WHERE tag=\"msa_mlss_id\" AND method_link_species_set_id=" + mlss_id);
-				if (multi_align_mlss_id == "") {
-					ReportManager.problem(this, con, "There is no msa_mlss_id tag for the GERP mlss" + mlss_id + "\n");
+		/**
+		 * Get all mlss_ids for the associated multiple alignment of each
+		 * method_link_species_set_id for method_link type of
+		 * GERP_CONSERVATION_SCORE
+		 */
+		List<String[]> msa_mlss_ids_list = DBUtils.getRowValuesList(con, "SELECT method_link_species_set_id, value FROM method_link_species_set LEFT JOIN method_link USING (method_link_id) LEFT JOIN method_link_species_set_tag USING (method_link_species_set_id) WHERE (type = \"GERP_CONSERVATION_SCORE\" OR class LIKE \"ConservationScore%\") AND tag = \"msa_mlss_id\"");
+			for (String[] msa_mlss_ids : msa_mlss_ids_list) {
+				if (msa_mlss_ids[1] == "") {
+					ReportManager.problem(this, con, "There is no msa_mlss_id tag for the GERP mlss" + msa_mlss_ids[0] + "\n");
 				} else {
+					/**
+					 * Even if the ancestral_sequences genome_db is there, it does
+					 * not mean that it is used by ALL the alignments, so we use
+					 * that extra information as an additional flag to run the
+					 * query faster
+					 */
+					String ancestral_align = DBUtils.getRowColumnValue(con, "SELECT * FROM method_link_species_set mlss LEFT JOIN method_link USING (method_link_id) WHERE method_link_species_set_id = "
+							+ msa_mlss_ids[1]
+							+ " AND class = \"GenomicAlignTree.ancestral_alignment\";");
 					/**
 					 * Find the multiple alignments gabs which have more than 3
 					 * species but don't have any conservation scores Need to
 					 * exclude gabs containing ancestral sequences
 					 */
 					String useful_sql;
-					if (ancestral_seq_id == "") {
+					if (ancestral_seq_id == "" || ancestral_align == "") {
 						useful_sql = "SELECT genomic_align_block.genomic_align_block_id FROM genomic_align_block LEFT JOIN genomic_align USING (genomic_align_block_id) LEFT JOIN conservation_score USING (genomic_align_block_id) WHERE genomic_align_block.method_link_species_set_id = "
-								+ multi_align_mlss_id
+								+ msa_mlss_ids[1]
 								+ " AND conservation_score.genomic_align_block_id IS NULL GROUP BY genomic_align_block.genomic_align_block_id HAVING count(*) > 3";
 					} else {
 						useful_sql = "SELECT genomic_align_block.genomic_align_block_id FROM genomic_align_block LEFT JOIN conservation_score USING (genomic_align_block_id) LEFT JOIN genomic_align USING (genomic_align_block_id) LEFT JOIN dnafrag USING (dnafrag_id) WHERE genomic_align_block.method_link_species_set_id = "
-								+ multi_align_mlss_id
+								+ msa_mlss_ids[1]
 								+ " AND conservation_score.genomic_align_block_id IS NULL AND genome_db_id <> "
 								+ ancestral_seq_id
 								+ " GROUP BY genomic_align_block.genomic_align_block_id HAVING count(*) > 3";
@@ -103,26 +108,25 @@ public class CheckConservationScorePerBlock extends SingleDatabaseTestCase {
 						 * score (default=0.5)
 						 */
 						String useful_sql4 = "SELECT genomic_align_block.genomic_align_block_id FROM genomic_align_block LEFT JOIN genomic_align USING (genomic_align_block_id) LEFT JOIN conservation_score USING (genomic_align_block_id) WHERE genomic_align_block.method_link_species_set_id = "
-								+ multi_align_mlss_id
+								+ msa_mlss_ids[1]
 								+ " AND conservation_score.genomic_align_block_id IS NULL GROUP BY genomic_align_block.genomic_align_block_id HAVING count(*) = 4";
 						String[] failures4 = DBUtils.getColumnValues(con,
 								useful_sql4);
 						if (failures.length == failures4.length) {
 							ReportManager.problem(this, con, "WARNING conservation_score -> multiple alignments which have more than 3 species but don't have any conservation scores");
-							ReportManager.problem(this, con, "WARNING DETAILS: There are " + failures.length + " blocks (mlss= " + multi_align_mlss_id
+							ReportManager.problem(this, con, "WARNING DETAILS: There are " + failures.length + " blocks (mlss= " + msa_mlss_ids[1]
 													+ ") with 4 seqs and no conservation score! Must check that the sum of the branch lengths of these 4 species is less than 0.5 (min_neu_evol). If it is greater than 0.5, there is a problem that needs fixing!");
 							ReportManager.problem(this, con, "USEFUL SQL: " + useful_sql4);
 
 						} else {
 							ReportManager.problem(this, con, "FAILED conservation_score -> multiple alignments which have more than 3 species but don't have any conservation scores");
-							ReportManager.problem(this, con, "FAILURE DETAILS: There are " + failures.length + " blocks (mlss= " + multi_align_mlss_id + ") with more than 4 seqs and no conservation score!");
+							ReportManager.problem(this, con, "FAILURE DETAILS: There are " + failures.length + " blocks (mlss= " + msa_mlss_ids[1] + ") with more than 4 seqs and no conservation score!");
 							ReportManager.problem(this, con, "USEFUL SQL: " + useful_sql);
 							result = false;
 						}
 					}
 				}
 			}
-		}
 
 		return result;
 


### PR DESCRIPTION
Ticket [ENSCOMPARASW-2219](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-2219).

Queries at lines 62 and 74 have been combined in a single one (new line 69), removed `if` at line 69 because the loop already takes care of that condition, and added additional control on lines 80 and 89 to reduce the number of cases where the `JOIN` of `dnafrag` is needed. Tested on `compara_ensembl_96` database, where the old version run for 12m 36s whilst the new one took 3m 31s.