### PR TITLE
Added a new meta-key used by Compara

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/compara/MetaSpeciesID.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/MetaSpeciesID.java
@@ -39,7 +39,7 @@ import org.ensembl.healthcheck.util.Utils; // needed for stringInArray
 
 public class MetaSpeciesID extends AbstractRepairableComparaTestCase {
 
-	String[] speciesless_meta_keys = { "schema_version", "schema_type", "patch" };
+	String[] speciesless_meta_keys = { "schema_version", "schema_type", "patch", "division" };
 
 	protected String getTableName() {
 		return "meta";


### PR DESCRIPTION
We've added this key in e98 (we don't use `species_id`)

This will have to be merged into master at some point