### PR TITLE
Make ensj-healthcheck compatible with OpenJDK v9+

### DIFF
--- a/src/org/ensembl/healthcheck/Debug.java
+++ b/src/org/ensembl/healthcheck/Debug.java
@@ -25,6 +25,16 @@ public class Debug {
 	public static String classpathToString() {
 		//Get the System Classloader
         ClassLoader sysClassLoader = ClassLoader.getSystemClassLoader();
+
+        // The code below only work with the interface provided by
+        // sun.misc.Launcher$AppClassLoader. OpenJDK since v9 returns a
+        // jdk.internal.loader.ClassLoaders$AppClassLoader
+        // Instead we can print the current CLASSPATH. It's not exactly the
+        // same format, but close enough when debugging
+        if (sysClassLoader.getClass().getName().startsWith("jdk.internal.loader")) {
+            return System.getProperty("java.class.path").replace(":", "\n");
+        }
+
         StringBuffer buf = new StringBuffer(); 
 
         //Get the URLs


### PR DESCRIPTION
There is some code in Debug.java that assumes that only works with a certain class interface used by the Oracle JVM. OpenJDK v8 had the same interface, but later versions use a different one.

My commit detects the new interface and returns an alternative. I couldn't find how to get _exactly_ the same output with the new interface, but I've got something that's close enough. I can do
```
./target/dist/ensj-healthcheck.jar
./lib/UmlGraph-5.3.jar
./lib/testng-6.5.2.jar
./lib/stringtemplate-3.2.1.jar
./lib/mysql-connector-java-5.1.26-bin.jar
./lib/looks-1.2.1.jar
./lib/jewelcli-0.6.jar
./lib/h2-1.3.162.jar
./lib/gson-2.1.jar
./lib/commons-lang-2.3.jar
./lib/commons-io-1.2.jar
./lib/commons-collections-3.2.1.jar
./lib/antlr-2.7.7.jar
.
./build/
src/
./resources/runtime
```
instead of
```
/ensj-healthcheck/target/dist/ensj-healthcheck.jar
/ensj-healthcheck/lib/testng-6.5.2.jar
/ensj-healthcheck/lib/stringtemplate-3.2.1.jar
/ensj-healthcheck/lib/mysql-connector-java-5.1.26-bin.jar
/ensj-healthcheck/lib/looks-1.2.1.jar
/ensj-healthcheck/lib/jewelcli-0.6.jar
/ensj-healthcheck/lib/h2-1.3.162.jar
/ensj-healthcheck/lib/gson-2.1.jar
/ensj-healthcheck/lib/commons-lang-2.3.jar
/ensj-healthcheck/lib/commons-io-1.2.jar
/ensj-healthcheck/lib/commons-collections-3.2.1.jar
/ensj-healthcheck/lib/antlr-2.7.7.jar
/ensj-healthcheck/lib/UmlGraph-5.3.jar
/ensj-healthcheck/
/ensj-healthcheck/build
/ensj-healthcheck/src/
/ensj-healthcheck/resources/runtime/
```

You can easily test this with Docker.
```
docker run -it openjdk:9 /bin//bash
apt-get update; apt-get install -y ant; git clone http://www.github.com/Ensembl/ensj-healthcheck; cd ensj-healthcheck; ant jar; ./run-configurable-testrunner.sh
```