### PR TITLE
Search for the compara master database with wildcards too

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/AbstractControlledTable.java
+++ b/src/org/ensembl/healthcheck/testcase/AbstractControlledTable.java
@@ -107,7 +107,6 @@ public abstract class AbstractControlledTable extends AbstractControlledRows {
 
 		String controlledTableToTest = getControlledTableName();
 		
-		DatabaseRegistryEntry masterDbRe = getComparaMasterDatabase();
 		Connection testDbConn = dbre.getConnection();
 		
 		if (masterDbRe==null) {

--- a/src/org/ensembl/healthcheck/testcase/AbstractControlledTable.java
+++ b/src/org/ensembl/healthcheck/testcase/AbstractControlledTable.java
@@ -107,6 +107,9 @@ public abstract class AbstractControlledTable extends AbstractControlledRows {
 		
 		Connection testDbConn = dbre.getConnection();
 		init(testDbConn);
+		if (masterDbRe == null) {
+			return false;
+		}
 		
 		boolean passed;
 		

--- a/src/org/ensembl/healthcheck/testcase/AbstractControlledTable.java
+++ b/src/org/ensembl/healthcheck/testcase/AbstractControlledTable.java
@@ -162,14 +162,14 @@ public abstract class AbstractControlledTable extends AbstractControlledRows {
 	protected boolean checkByChecksum(
 			final String controlledTableToTest,
 			DatabaseRegistryEntry testDbRe,
-			DatabaseRegistryEntry masterDbRe
+			DatabaseRegistryEntry refDbre
 		) {
 		
 		List<String> tablesToChecksum = new ArrayList<String>();
 		tablesToChecksum.add(controlledTableToTest);
 		
 		String checksumValueMaster = calculateChecksumForTable(
-				masterDbRe, tablesToChecksum);
+				refDbre, tablesToChecksum);
 		
 		String checksumValueTest = calculateChecksumForTable(
 				testDbRe, tablesToChecksum);
@@ -209,43 +209,43 @@ public abstract class AbstractControlledTable extends AbstractControlledRows {
 	/**
 	 * For every row of the table controlledTableToTest in the database 
 	 * testDbre this checks, if this row also exists in the table 
-	 * controlledTableToTest of masterDbRe.
+	 * controlledTableToTest of refDbre.
 	 * 
 	 * @param controlledTableToTest
 	 * @param testDbre
-	 * @param masterDbRe
+	 * @param refDbre
 	 * @return true if rows exist
 	 */
 	protected boolean checkAllRowsInTable(
 			final String controlledTableToTest,
 			DatabaseRegistryEntry testDbre,
-			DatabaseRegistryEntry masterDbRe
+			DatabaseRegistryEntry refDbre
 		) {
-		return checkAllRowsInTable(controlledTableToTest, controlledTableToTest, testDbre, masterDbRe);		
+		return checkAllRowsInTable(controlledTableToTest, controlledTableToTest, testDbre, refDbre);
 	}
 	
 	/**
 	 * For every row of the table controlledTableToTest in the database 
 	 * testDbre this checks, if this row also exists in the table 
-	 * masterTable of masterDbRe.
+	 * masterTable of refDbre.
 	 * 
 	 * @param controlledTableToTest
 	 * @param masterTable
 	 * @param testDbre
-	 * @param masterDbRe
+	 * @param refDbre
 	 * @return true if rows exist
 	 */
 	protected boolean checkAllRowsInTable(
 			final String controlledTableToTest,
 			final String masterTable,
 			DatabaseRegistryEntry testDbre,
-			DatabaseRegistryEntry masterDbRe
+			DatabaseRegistryEntry refDbre
 		) {
 		
 		final Logger logger = getLogger();
 		
 		final Connection testDbConn = testDbre.getConnection();
-		final Connection masterconn = masterDbRe.getConnection();
+		final Connection masterconn = refDbre.getConnection();
 
 		final SqlTemplate sqlTemplateTestDb        = getSqlTemplate(testDbConn);  
 		
@@ -293,7 +293,7 @@ public abstract class AbstractControlledTable extends AbstractControlledRows {
 				controlledTableToTest,
 				masterTable,
 				testDbre,
-				masterDbRe,
+				refDbre,
 				limit,
 				currentOffset
 			);			

--- a/src/org/ensembl/healthcheck/testcase/AbstractControlledTable.java
+++ b/src/org/ensembl/healthcheck/testcase/AbstractControlledTable.java
@@ -95,13 +95,6 @@ public abstract class AbstractControlledTable extends AbstractControlledRows {
 		Checksum 
 	};
 
-	/**
-	 * DatabaseRegistryEntry of the master database.
-	 */
-	protected DatabaseRegistryEntry getMasterDatabase() {
-		return getComparaMasterDatabase();
-	}
-
 	public AbstractControlledTable() {
 		setTypeFromPackageName();
 		setTeamResponsible(Team.ENSEMBL_GENOMES);
@@ -114,7 +107,7 @@ public abstract class AbstractControlledTable extends AbstractControlledRows {
 
 		String controlledTableToTest = getControlledTableName();
 		
-		DatabaseRegistryEntry masterDbRe = getMasterDatabase();
+		DatabaseRegistryEntry masterDbRe = getComparaMasterDatabase();
 		Connection testDbConn = dbre.getConnection();
 		
 		if (masterDbRe==null) {

--- a/src/org/ensembl/healthcheck/testcase/AbstractControlledTable.java
+++ b/src/org/ensembl/healthcheck/testcase/AbstractControlledTable.java
@@ -102,22 +102,11 @@ public abstract class AbstractControlledTable extends AbstractControlledRows {
 	
 	@Override
 	protected boolean runTest(DatabaseRegistryEntry dbre) {
-		
-		init();
 
 		String controlledTableToTest = getControlledTableName();
 		
 		Connection testDbConn = dbre.getConnection();
-		
-		if (masterDbRe==null) {
-			ReportManager.problem(
-				this, 
-				testDbConn, 
-				"Can't get connection to master database! Perhaps it has not been "
-				+"configured?"
-			);
-			return false;
-		}
+		init(testDbConn);
 		
 		boolean passed;
 		

--- a/src/org/ensembl/healthcheck/testcase/EnsTestCase.java
+++ b/src/org/ensembl/healthcheck/testcase/EnsTestCase.java
@@ -762,10 +762,27 @@ public abstract class EnsTestCase {
 	 */
 	public DatabaseRegistryEntry getComparaMasterDatabase() {
 
-		// return existing one if we already have it, otherwise use method above
-		// to find it
-		return comparaMasterDbre != null ? comparaMasterDbre
-				: getDatabaseRegistryEntryByPattern(System.getProperty("compara_master.database"));
+		// return existing one if we already have it, e.g. it's been set by
+		// StandaloneTestRunner because the user has been explicit about
+		// its location, or we've already run this method
+		if (comparaMasterDbre != null) {
+			return comparaMasterDbre;
+		}
+
+		String masterPattern = System.getProperty("compara_master.database");
+
+		// First looking for an exact match
+		comparaMasterDbre = getDatabaseRegistryEntryByPattern(masterPattern);
+		if (comparaMasterDbre != null) {
+			return comparaMasterDbre;
+		}
+
+		// Then adding wildcards if none are provided
+		if (!masterPattern.contains("%") && !masterPattern.contains(".*")) {
+			comparaMasterDbre = getDatabaseRegistryEntryByPattern("%" + masterPattern + "%");
+		}
+
+		return comparaMasterDbre;
 
 	}
 	

--- a/src/org/ensembl/healthcheck/testcase/eg_compara/AbstractControlledRows.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_compara/AbstractControlledRows.java
@@ -48,7 +48,7 @@ abstract public class AbstractControlledRows extends AbstractTemplatedTestCase {
 			final String controlledTableToTest,
 			final String masterTable,
 			DatabaseRegistryEntry testDbre,
-			DatabaseRegistryEntry masterDbRe,
+			DatabaseRegistryEntry refDbre,
 			int limit,
 			int offset
 		) {
@@ -56,7 +56,7 @@ abstract public class AbstractControlledRows extends AbstractTemplatedTestCase {
 				controlledTableToTest,
 				masterTable,
 				testDbre,
-				masterDbRe,
+				refDbre,
 				"",
 				limit,
 				offset
@@ -66,21 +66,21 @@ abstract public class AbstractControlledRows extends AbstractTemplatedTestCase {
 	/**
 	 * For every row of the table controlledTableToTest in the database 
 	 * testDbre this checks, if this row also exists in the table 
-	 * masterTable of masterDbRe.
+	 * masterTable of refDbre.
 	 * 
 	 */
 	protected boolean checkRangeOfRowsInTable(
 			final String controlledTableToTest,
 			final String masterTable,
 			DatabaseRegistryEntry testDbre,
-			DatabaseRegistryEntry masterDbRe,
+			DatabaseRegistryEntry refDbre,
 			String whereClause,
 			int limit,
 			int offset
 		) {
 
 		final Connection testDbConn = testDbre.getConnection();
-		final Connection masterconn = masterDbRe.getConnection();
+		final Connection masterconn = refDbre.getConnection();
 		
 		final SqlTemplate sqlTemplateTestDb        = getSqlTemplate(testDbConn);  
 		final SqlTemplate sqlTemplateComparaMaster = getSqlTemplate(masterconn);

--- a/src/org/ensembl/healthcheck/testcase/eg_compara/AbstractControlledRows.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_compara/AbstractControlledRows.java
@@ -39,8 +39,18 @@ abstract public class AbstractControlledRows extends AbstractTemplatedTestCase {
 	protected Connection masterDbConn;
 	protected SqlTemplate masterSqlTemplate;
 
-	protected void init() {
+	protected void init(Connection conn) {
 		masterDbRe = getComparaMasterDatabase();
+
+		if (masterDbRe == null) {
+			ReportManager.problem(
+				this,
+				conn,
+				"Can't get connection to master database! Perhaps it has not been configured?"
+			);
+			return;
+		}
+
 		masterDbConn = masterDbRe.getConnection();
 		masterSqlTemplate = getSqlTemplate(masterDbConn);		
 	}

--- a/src/org/ensembl/healthcheck/testcase/eg_compara/AbstractControlledRows.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_compara/AbstractControlledRows.java
@@ -35,11 +35,12 @@ import org.ensembl.healthcheck.util.SqlTemplate.ResultSetCallback;
 
 abstract public class AbstractControlledRows extends AbstractTemplatedTestCase {
 
+	protected DatabaseRegistryEntry masterDbRe;
 	protected Connection masterDbConn;
 	protected SqlTemplate masterSqlTemplate;
 
 	protected void init() {
-		DatabaseRegistryEntry masterDbRe = getComparaMasterDatabase();
+		masterDbRe = getComparaMasterDatabase();
 		masterDbConn = masterDbRe.getConnection();
 		masterSqlTemplate = getSqlTemplate(masterDbConn);		
 	}

--- a/src/org/ensembl/healthcheck/testcase/eg_compara/ControlledTableDnafrag.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_compara/ControlledTableDnafrag.java
@@ -35,21 +35,10 @@ public class ControlledTableDnafrag extends AbstractControlledRows {
 	@Override
 	protected boolean runTest(DatabaseRegistryEntry dbre) {
 
-		init();
-		
 		String controlledTableToTest = getControlledTableName();
 		
 		Connection testDbConn = dbre.getConnection();
-		
-		if (masterDbRe==null) {
-			ReportManager.problem(
-				this, 
-				testDbConn, 
-				"Can't get connection to master database! Perhaps it has not been "
-				+"configured?"
-			);
-			return false;
-		}
+		init(testDbConn);
 		
 		boolean passed = checkAllRowsInTableIfInDnaCompara(controlledTableToTest, getControlledTableName(), dbre, masterDbRe);
 		

--- a/src/org/ensembl/healthcheck/testcase/eg_compara/ControlledTableDnafrag.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_compara/ControlledTableDnafrag.java
@@ -63,16 +63,16 @@ public class ControlledTableDnafrag extends AbstractControlledRows {
 			final String controlledTableToTest,
 			final String masterTable,
 			DatabaseRegistryEntry testDbre,
-			DatabaseRegistryEntry masterDbRe
+			DatabaseRegistryEntry refDbre
 		) {
-		return checkAllRowsInTableIfInDnaCompara(controlledTableToTest, masterTable, testDbre, masterDbRe);
+		return checkAllRowsInTableIfInDnaCompara(controlledTableToTest, masterTable, testDbre, refDbre);
 	}
 		
 	protected boolean allDnaFragForSpeciesInComparaMaster(
 			final String controlledTableToTest,
 			final String masterTable,
 			DatabaseRegistryEntry testDbre,
-			DatabaseRegistryEntry masterDbRe,
+			DatabaseRegistryEntry refDbre,
 			String speciesName
 ) {
 		//checkRangeOfRowsInTable
@@ -81,7 +81,7 @@ public class ControlledTableDnafrag extends AbstractControlledRows {
 		final Logger logger = getLogger();
 		
 		final Connection testDbConn = testDbre.getConnection();
-		final Connection masterconn = masterDbRe.getConnection();
+		final Connection masterconn = refDbre.getConnection();
 
 		final SqlTemplate sqlTemplateTestDb        = getSqlTemplate(testDbConn);  
 
@@ -136,7 +136,7 @@ public class ControlledTableDnafrag extends AbstractControlledRows {
 				controlledTableToTest,
 				masterTable,
 				testDbre,
-				masterDbRe,
+				refDbre,
 				whereClause,
 				limit,
 				currentOffset
@@ -149,7 +149,7 @@ public class ControlledTableDnafrag extends AbstractControlledRows {
 			final String controlledTableToTest,
 			final String masterTable,
 			DatabaseRegistryEntry testDbre,
-			DatabaseRegistryEntry masterDbRe
+			DatabaseRegistryEntry refDbre
 		) {
 		
 		final Connection testDbConn = testDbre.getConnection();		
@@ -172,7 +172,7 @@ public class ControlledTableDnafrag extends AbstractControlledRows {
 					controlledTableToTest,
 					masterTable,
 					testDbre,
-					masterDbRe,
+					refDbre,
 					currentSpeciesNameInComparaDb
 				);
 				allSpeciesPass = allSpeciesPass && currentSpeciesPasses;

--- a/src/org/ensembl/healthcheck/testcase/eg_compara/ControlledTableDnafrag.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_compara/ControlledTableDnafrag.java
@@ -39,7 +39,6 @@ public class ControlledTableDnafrag extends AbstractControlledRows {
 		
 		String controlledTableToTest = getControlledTableName();
 		
-		DatabaseRegistryEntry masterDbRe = getComparaMasterDatabase();
 		Connection testDbConn = dbre.getConnection();
 		
 		if (masterDbRe==null) {

--- a/src/org/ensembl/healthcheck/testcase/eg_compara/ControlledTableDnafrag.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_compara/ControlledTableDnafrag.java
@@ -39,10 +39,11 @@ public class ControlledTableDnafrag extends AbstractControlledRows {
 		
 		Connection testDbConn = dbre.getConnection();
 		init(testDbConn);
+		if (masterDbRe == null) {
+			return false;
+		}
 		
 		boolean passed = checkAllRowsInTableIfInDnaCompara(controlledTableToTest, getControlledTableName(), dbre, masterDbRe);
-		
-		//ReportManager.problem(this, testDbConn, "Not implemented yet!");		
 		
 		return passed;
 	}

--- a/src/org/ensembl/healthcheck/testcase/eg_compara/ControlledTableDnafrag.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_compara/ControlledTableDnafrag.java
@@ -32,13 +32,6 @@ public class ControlledTableDnafrag extends AbstractControlledRows {
 		return "dnafrag";	
 	}
 
-	/**
-	 * DatabaseRegistryEntry of the master database.
-	 */
-	protected DatabaseRegistryEntry getMasterDatabase() {
-		return getComparaMasterDatabase();
-	}
-
 	@Override
 	protected boolean runTest(DatabaseRegistryEntry dbre) {
 
@@ -46,7 +39,7 @@ public class ControlledTableDnafrag extends AbstractControlledRows {
 		
 		String controlledTableToTest = getControlledTableName();
 		
-		DatabaseRegistryEntry masterDbRe = getMasterDatabase();
+		DatabaseRegistryEntry masterDbRe = getComparaMasterDatabase();
 		Connection testDbConn = dbre.getConnection();
 		
 		if (masterDbRe==null) {

--- a/src/org/ensembl/healthcheck/testcase/eg_core/SeqRegionAttribForPolyploidGenome.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_core/SeqRegionAttribForPolyploidGenome.java
@@ -26,7 +26,7 @@ import org.ensembl.healthcheck.DatabaseRegistryEntry;
 import org.ensembl.healthcheck.ReportManager;
 import org.ensembl.healthcheck.Team;
 import org.ensembl.healthcheck.testcase.EnsTestCase;
-import org.ensembl.healthcheck.testcase.eg_compara.AbstractControlledRows;
+import org.ensembl.healthcheck.testcase.AbstractTemplatedTestCase;
 import org.ensembl.healthcheck.util.SqlTemplate;
 import org.ensembl.healthcheck.util.SqlUncheckedException;
 import org.ensembl.healthcheck.util.SqlTemplate.ResultSetCallback;
@@ -39,16 +39,12 @@ import org.ensembl.healthcheck.util.SqlTemplate.ResultSetCallback;
  * @author arnaud
  *
  */
-public class SeqRegionAttribForPolyploidGenome extends AbstractControlledRows {
+public class SeqRegionAttribForPolyploidGenome extends AbstractTemplatedTestCase {
 
-	final int reportMaxMissingRows = 1;
-	
 	protected Connection testDbConn;
 	protected SqlTemplate sqlTemplateTestDb;
 	
 	protected void init(DatabaseRegistryEntry dbre) {
-		
-		super.init();
 		
 		testDbConn   = dbre.getConnection();
 		sqlTemplateTestDb = getSqlTemplate(testDbConn);

--- a/src/org/ensembl/healthcheck/testcase/eg_core/SeqRegionAttribForPolyploidGenomeToplevelOnly.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_core/SeqRegionAttribForPolyploidGenomeToplevelOnly.java
@@ -26,7 +26,7 @@ import org.ensembl.healthcheck.DatabaseRegistryEntry;
 import org.ensembl.healthcheck.ReportManager;
 import org.ensembl.healthcheck.Team;
 import org.ensembl.healthcheck.testcase.EnsTestCase;
-import org.ensembl.healthcheck.testcase.eg_compara.AbstractControlledRows;
+import org.ensembl.healthcheck.testcase.AbstractTemplatedTestCase;
 import org.ensembl.healthcheck.util.SqlTemplate;
 import org.ensembl.healthcheck.util.SqlUncheckedException;
 import org.ensembl.healthcheck.util.SqlTemplate.ResultSetCallback;
@@ -39,16 +39,12 @@ import org.ensembl.healthcheck.util.SqlTemplate.ResultSetCallback;
  * @author arnaud
  *
  */
-public class SeqRegionAttribForPolyploidGenomeToplevelOnly extends AbstractControlledRows {
+public class SeqRegionAttribForPolyploidGenomeToplevelOnly extends AbstractTemplatedTestCase {
 
-	final int reportMaxMissingRows = 1;
-	
 	protected Connection testDbConn;
 	protected SqlTemplate sqlTemplateTestDb;
 	
 	protected void init(DatabaseRegistryEntry dbre) {
-		
-		super.init();
 		
 		testDbConn   = dbre.getConnection();
 		sqlTemplateTestDb = getSqlTemplate(testDbConn);

--- a/src/org/ensembl/healthcheck/testcase/eg_core/SeqRegionsConsistentWithComparaMaster.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_core/SeqRegionsConsistentWithComparaMaster.java
@@ -61,6 +61,9 @@ public class SeqRegionsConsistentWithComparaMaster extends AbstractControlledRow
 	protected boolean runTest(DatabaseRegistryEntry dbre) {
 
 		init(dbre);
+		if (masterDbRe == null) {
+			return false;
+		}
 		
 		List<Integer> allSpeciesIds = sqlTemplateTestDb.queryForDefaultObjectList(
 			"select distinct species_id from meta where species_id is not null", 

--- a/src/org/ensembl/healthcheck/testcase/eg_core/SeqRegionsConsistentWithComparaMaster.java
+++ b/src/org/ensembl/healthcheck/testcase/eg_core/SeqRegionsConsistentWithComparaMaster.java
@@ -49,10 +49,9 @@ public class SeqRegionsConsistentWithComparaMaster extends AbstractControlledRow
 	
 	protected void init(DatabaseRegistryEntry dbre) {
 		
-		super.init();
-		
 		testDbConn   = dbre.getConnection();
 		sqlTemplateTestDb = getSqlTemplate(testDbConn);
+		init(testDbConn);
 		
 		setTeamResponsible(Team.ENSEMBL_GENOMES);
 	}


### PR DESCRIPTION
This PR is a mixed bag of commits related to the Compara master database and the eg_compara.Controlled* test-cases. My main motivation was to make the code that searches for the master database use wildcards.

In terms of functionality, the only things that change are:
- When it can't find a database named `ensembl_compara_master` (the default name), it will search databases that contain that string in the name. That will make our live easier as we name the database `enseml_compara_master_${division}`. This also makes it consistent with `AbstractComparaTestCase.isMasterDB`, which checks whether the name _contains_ `ensembl_compar_master`
- The tests that need the master database will gracefully exit if it can't be found (rather than raising `NullPointerException`)

Other changes:
- I have disconnected two eg_core test-cases from the Compara base class because they're not related to Compara

(Although, it'd be useful to have those changes on the e98 branch, I don't think it qualifies as "bugfix", so master instead)