### PR TITLE
We decided to remove the AssemblyExceptionTableSeqMapping hc from the…

### DIFF
--- a/src/org/ensembl/healthcheck/testgroup/GenebuildPostHandoverService.java
+++ b/src/org/ensembl/healthcheck/testgroup/GenebuildPostHandoverService.java
@@ -18,6 +18,7 @@
 package org.ensembl.healthcheck.testgroup;
 
 import org.ensembl.healthcheck.testcase.generic.EmptyTables;
+import org.ensembl.healthcheck.testcase.generic.AssemblyExceptionTableSeqMapping;
 
 /**
  * These are the critical checks to run once Genebuild have handed over the core
@@ -27,5 +28,6 @@ public class GenebuildPostHandoverService extends GenebuildPostHandover {
 
   public GenebuildPostHandoverService() {
     this.removeTest(EmptyTables.class);
+    this.removeTest(AssemblyExceptionTableSeqMapping.class);
   }
 }


### PR DESCRIPTION
… handover service group since it only applies to human and mouse and has been failing for a long time.