### PR TITLE
Ignore LRGs for all Compara divisions but vertebrates

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/compara/AbstractComparaTestCase.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/AbstractComparaTestCase.java
@@ -235,6 +235,12 @@ public abstract class AbstractComparaTestCase extends SingleDatabaseTestCase {
 	protected final static Pattern EC_DB = Pattern.compile("^([^_]+_)?ensembl_compara_[0-9]+");
 
 	String getComparaDivisionName(DatabaseRegistryEntry compara_dbre) {
+		Connection compara_con = compara_dbre.getConnection();
+		String sql_division = "SELECT meta_value FROM meta WHERE meta_key = 'division'";
+		String division = DBUtils.getRowColumnValue(compara_con, sql_division);
+		if (! division.isEmpty()) {
+			return division;
+		}
 		Matcher m = EGC_DB.matcher(compara_dbre.getName());
 		if (m.matches()) {
 			if (m.groupCount() > 1) {
@@ -245,12 +251,13 @@ public abstract class AbstractComparaTestCase extends SingleDatabaseTestCase {
 		} else {
 			m = EC_DB.matcher(compara_dbre.getName());
 			if (m.matches()) {
-				return "ensembl";
+				return "vertebrates";
 			} else {
 				ReportManager.problem(this, compara_dbre.getConnection(), "Cannot find the division name of this database: '" + compara_dbre.getName() + "'");
 				return null;
 			}
 		}
+
 	}
 
 } // AbstractComparaTestCase

--- a/src/org/ensembl/healthcheck/testcase/compara/CheckGenomicAlignCoverage.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/CheckGenomicAlignCoverage.java
@@ -70,8 +70,7 @@ public class CheckGenomicAlignCoverage extends AbstractComparaTestCase {
 		 *  - Check if we're working with vertebrates or not
 		 *  - Set the overlap check accordingly
 		 */
-		String division_sql = "SELECT meta_value FROM meta WHERE meta_key = 'division'";
-		String division = DBUtils.getRowColumnValue(con, division_sql);
+		String division = getComparaDivisionName(dbre);
 		String overlap_check = "1"; // non-vertebrate default : overlaps always allowed
 		if ( division.equals("vertebrates") ) {
 			// vertebrate-specific condition : overlaps only expected in some cases

--- a/src/org/ensembl/healthcheck/testcase/compara/CheckTopLevelDnaFrag.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/CheckTopLevelDnaFrag.java
@@ -73,7 +73,7 @@ public class CheckTopLevelDnaFrag extends AbstractComparaTestCase {
 		Connection comparaCon = comparaDbre.getConnection();
 
 		// LRGs are only required by vertebrates division
-		String division = DBUtils.getRowColumnValue(comparaCon, "SELECT meta_value FROM meta WHERE meta_key = 'division'");
+		String division = getComparaDivisionName(comparaDbre);
 		String dnafragLRGFilter = "";
 		String coordsysLRGFilter = "";
 		if (! division.equals("vertebrates")) {

--- a/src/org/ensembl/healthcheck/testcase/compara/CheckTopLevelDnaFrag.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/CheckTopLevelDnaFrag.java
@@ -72,6 +72,15 @@ public class CheckTopLevelDnaFrag extends AbstractComparaTestCase {
 		boolean result = true;
 		Connection comparaCon = comparaDbre.getConnection();
 
+		// LRGs are only required by vertebrates division
+		String division = DBUtils.getRowColumnValue(comparaCon, "SELECT meta_value FROM meta WHERE meta_key = 'division'");
+		String dnafragLRGFilter = "";
+		String coordsysLRGFilter = "";
+		if (! division.equals("vertebrates")) {
+			dnafragLRGFilter = " AND dnafrag.coord_system_name != 'lrg'";
+			coordsysLRGFilter = " AND coord_system.name != 'lrg'";
+		}
+
 		for (GenomeEntry genomeEntry : getAllGenomes(comparaDbre, DBUtils.getMainDatabaseRegistry())) {
 			if (genomeEntry.getCoreDbre() != null) {
 				Connection speciesCon = genomeEntry.getCoreDbre().getConnection();
@@ -82,6 +91,7 @@ public class CheckTopLevelDnaFrag extends AbstractComparaTestCase {
 					for (int rowCount=0; rowCount<rows; rowCount+=maxRows) {
 						String sql1 = "SELECT dnafrag.coord_system_name, dnafrag.name, CONCAT('length=', dnafrag.length), CONCAT('is_ref=', dnafrag.is_reference)" +
 							" FROM dnafrag WHERE genome_db_id = " + genomeEntry.getGenomeDBID() +
+							dnafragLRGFilter +
 							" ORDER BY (dnafrag.name)" +
 							" LIMIT " + rowCount + ", " + maxRows;
 						String sql2 = "SELECT coord_system.name, seq_region.name, CONCAT('length=', seq_region.length),"+
@@ -92,6 +102,7 @@ public class CheckTopLevelDnaFrag extends AbstractComparaTestCase {
 							" JOIN attrib_type USING (attrib_type_id)" +
 							" LEFT JOIN (SELECT seq_region_id FROM seq_region_attrib JOIN attrib_type USING (attrib_type_id) WHERE attrib_type.code = 'non_ref') non_ref_seq_region USING (seq_region_id)" +
 							" WHERE attrib_type.code = 'toplevel'" +
+							coordsysLRGFilter +
 							" AND species_id = " + genomeEntry.getSpeciesID() +
 							" ORDER BY (seq_region.name)" +
 							" LIMIT " + rowCount + ", " + maxRows;
@@ -99,7 +110,8 @@ public class CheckTopLevelDnaFrag extends AbstractComparaTestCase {
 					}
 				} else {
 					String sql1 = "SELECT dnafrag.coord_system_name, dnafrag.name, CONCAT('length=', dnafrag.length), CONCAT('is_ref=', dnafrag.is_reference)" +
-						" FROM dnafrag WHERE genome_db_id = " + genomeEntry.getGenomeDBID();
+						" FROM dnafrag WHERE genome_db_id = " + genomeEntry.getGenomeDBID() +
+						dnafragLRGFilter;
 					String sql2 = "SELECT coord_system.name, seq_region.name, CONCAT('length=', seq_region.length),"+
 						" CONCAT('is_ref=', IF(non_ref_seq_region.seq_region_id is not null, 0, 1))" +
 						" FROM seq_region" +
@@ -108,6 +120,7 @@ public class CheckTopLevelDnaFrag extends AbstractComparaTestCase {
 						" JOIN attrib_type USING (attrib_type_id)" +
 						" LEFT JOIN (SELECT seq_region_id FROM seq_region_attrib JOIN attrib_type USING (attrib_type_id) WHERE attrib_type.code = 'non_ref') non_ref_seq_region USING (seq_region_id)" +
 						" WHERE attrib_type.code = 'toplevel'" +
+						coordsysLRGFilter +
 						" AND species_id = " + genomeEntry.getSpeciesID();
 					result &= compareQueries(comparaCon, sql1, speciesCon, sql2);
 				}


### PR DESCRIPTION
In Compara we do not use LRGs for other divisions than vertebrates. In fact, we have stopped copying then, which is making `CheckTopLevelDnaFrag` HC to fail since some LRGs are missing for plants division. This patch fixes the problem, not comparing LRGs between _ensembl_compara_master_ and _homo_sapiens_core_ databases when the division is not vertebrates.