### PR TITLE
Relaxed name constrain for Compara master databases

### DIFF
--- a/src/org/ensembl/healthcheck/StandaloneTestRunner.java
+++ b/src/org/ensembl/healthcheck/StandaloneTestRunner.java
@@ -111,7 +111,7 @@ public class StandaloneTestRunner {
 
 		boolean isPort();
 
-		@Option(longName = "compara_dbname", defaultValue = "ensembl_compara_master", description = "Name of compara master database")
+		@Option(longName = "compara_dbname", defaultValue = "compara_master", description = "Name of compara master database")
 		String getComparaMasterDbname();
 
 		boolean isComparaMasterDbname();

--- a/src/org/ensembl/healthcheck/SystemPropertySetter.java
+++ b/src/org/ensembl/healthcheck/SystemPropertySetter.java
@@ -253,7 +253,7 @@ public class SystemPropertySetter {
 			//
 			System.setProperty("compara_master.database", configuration.getComparaMasterDatabase());
 		} else {
-			System.setProperty("compara_master.database", "ensembl_compara_master");
+			System.setProperty("compara_master.database", "compara_master");
 		}
 	}
 }


### PR DESCRIPTION
The previous name constrain `ensembl_compara_master` makes HCs treat new Compara master databases we are creating for internal use (e.g. pipeline testing) not as master databases because they lack the "ensembl_" part in their name. This is also the case for EG databases. I have reduced this constrain to search only for `compara_master` instead.