### PR TITLE
bugfix: correctly set the internal name of the ensembl_ancestral_XX database

### DIFF
--- a/src/org/ensembl/healthcheck/DatabaseRegistryEntry.java
+++ b/src/org/ensembl/healthcheck/DatabaseRegistryEntry.java
@@ -398,7 +398,7 @@ public class DatabaseRegistryEntry implements Comparable<DatabaseRegistryEntry> 
 		if (type == null) {
 			if (!StringUtils.isEmpty(typeStr)) {
 				type = DatabaseType.resolveAlias(typeStr);
-				if (typeStr.equals("ancestral") && species == UNKNOWN) {
+				if (typeStr.equals("ancestral") && species.equals("ensembl")) {
 					species = ANCESTRAL_SEQUENCES;
 				}
 			} else {


### PR DESCRIPTION
Since Species.java was removed, "species" remains `ensembl` at this stage instead of being turned into _UNKNOWN_.
When the name is not set correctly, several HCs start complaining about stuff that is not relevant to the ancestral database