### PR TITLE
Compara gene_member_hom_stats <-> gene_member

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
@@ -55,6 +55,7 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 		// Check the counts for each collection name
 		for (String collection : allCollectionNames) {
 			result &= checkCountsForCollection(dbre, collection);
+			result &= checkCountsForGenomeDBsInCollection(dbre, collection);
 		}
 
 		return result;
@@ -183,6 +184,20 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 				"gene_trees = 0 AND collection = clusterset_id AND collection = '" + collection + "'"
 				);
 
+		return result;
+	}
+
+	private boolean checkCountsForGenomeDBsInCollection(DatabaseRegistryEntry dbre, String collection) {
+		SqlTemplate srv = getSqlTemplate(dbre);
+		Connection con  = dbre.getConnection();
+
+		String sqlAllGenomeDBs = "SELECT DISTINCT genome_db_id FROM gene_tree_root JOIN method_link_species_set USING (method_link_species_set_id) JOIN species_set USING (species_set_id) WHERE clusterset_id = \"" + collection + "\"";
+		String[] genome_db_ids = DBUtils.getColumnValues(con, sqlAllGenomeDBs);
+
+		boolean result = true;
+		for (String genome_db_id : genome_db_ids) {
+			result &= checkCountIsNonZero(con, "gene_member_hom_stats JOIN gene_member USING (gene_member_id)", "collection = \"" + collection + "\" AND genome_db_id = " + genome_db_id + " LIMIT 1");
+		}
 		return result;
 	}
 }

--- a/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
@@ -24,6 +24,20 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 
 	@Override
 	protected boolean runTest(DatabaseRegistryEntry dbre) {
+		Connection con  = dbre.getConnection();
+
+		boolean result = true;
+
+		// All the gene_member_ids must exist
+		result &= checkForOrphans(con, "gene_member_hom_stats", "gene_member_id", "gene_member", "gene_member_id");
+
+		// Check every collection
+		result &= checkCountsForAllCollections(dbre);
+
+		return result;
+	}
+
+	private boolean checkCountsForAllCollections(DatabaseRegistryEntry dbre) {
 
 		// All the possible collection names
 		List<String> allCollectionNames = DBUtils.getColumnValuesList(dbre.getConnection(), "SELECT DISTINCT clusterset_id FROM gene_tree_root WHERE tree_type = \"tree\" AND ref_root_id IS NULL");


### PR DESCRIPTION
Here are extra checks that would have prevented https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?pageId=101064429#id-98/45-Late/post-releaseupdates-Mouse-strainstreesnotavailablefromthereferencemouse

1. Test that all the gene_member_ids are valid
2. Test that all the species are represented