### PR TITLE
genomic_align_tree tests

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/compara/CheckGenomicAlignTreeTable.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/CheckGenomicAlignTreeTable.java
@@ -53,9 +53,10 @@ public class CheckGenomicAlignTreeTable extends AbstractComparaTestCase {
 		for (String mlss_id: method_link_species_set_ids) {
 			String mlss_id_condition = "FLOOR(node_id/10000000000) = " + mlss_id;
 
-			// Check the left_node_id values are set (and assume right_node_ids have also been set)
-			// FIXME: this will have to be updated when left_node_id becomes NULLable
-			result &= checkCountIsNonZero(con, "genomic_align_tree", mlss_id_condition + " AND left_node_id != 0");
+			// Check the NULLable columns are not always NULL
+			result &= checkCountIsNonZero(con, "genomic_align_tree", mlss_id_condition + " AND parent_id IS NOT NULL");
+			result &= checkCountIsNonZero(con, "genomic_align_tree", mlss_id_condition + " AND left_node_id IS NOT NULL");
+			result &= checkCountIsNonZero(con, "genomic_align_tree", mlss_id_condition + " AND right_node_id IS NOT NULL");
 
 			/* Looking at distance_to_parent > 1 is true for LOW_COVERAGE but not epo */
 			/* Update 2015-30-04: there are nodes with distance_to_parent > 1

--- a/src/org/ensembl/healthcheck/testcase/compara/CheckGenomicAlignTreeTable.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/CheckGenomicAlignTreeTable.java
@@ -68,7 +68,7 @@ public class CheckGenomicAlignTreeTable extends AbstractComparaTestCase {
 			if (100 * n_bad_dist_rows < 1 * n_rows) {
 				ReportManager.correct(this, con, "distance_to_parent<1 alignment mlss_id=" + mlss_id);
 			} else {
-				ReportManager.problem(this, con, "distance_to_parent<1 for " + n_bad_dist_rows + " rows out of " + n_rows + " for alignment mlss_id=" + mlss_id);
+				ReportManager.problem(this, con, "distance_to_parent>1 for " + n_bad_dist_rows + " rows out of " + n_rows + " for alignment mlss_id=" + mlss_id);
 				result = false;
 			}
 		}


### PR DESCRIPTION
Various changes that would have prevented the issue with the EPO alignments on GRCh37 back in e95, see https://www.ebi.ac.uk/seqdb/confluence/display/GTI/2018-11-26+-+Relco+meeting#id-2018-11-26-Relcomeeting-Compara (that ultimately led to that handover being cancelled)

1) Check each alignment separately, not the whole table with everything combined
2) Check for NULL values
3) Check for unexpected distances