### PR TITLE
Compara HC fixes

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/compara/CheckConservationScorePerBlock.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/CheckConservationScorePerBlock.java
@@ -87,15 +87,15 @@ public class CheckConservationScorePerBlock extends SingleDatabaseTestCase {
 					 */
 					String useful_sql;
 					if (ancestral_seq_id == "" || ancestral_align == "") {
-						useful_sql = "SELECT genomic_align_block.genomic_align_block_id FROM genomic_align_block LEFT JOIN genomic_align USING (genomic_align_block_id) LEFT JOIN conservation_score USING (genomic_align_block_id) WHERE genomic_align_block.method_link_species_set_id = "
+						useful_sql = "SELECT genomic_align_block.genomic_align_block_id FROM genomic_align_block LEFT JOIN genomic_align USING (genomic_align_block_id) LEFT JOIN conservation_score USING (genomic_align_block_id) JOIN dnafrag USING(dnafrag_id) WHERE genomic_align_block.method_link_species_set_id = "
 								+ msa_mlss_ids[1]
-								+ " AND conservation_score.genomic_align_block_id IS NULL GROUP BY genomic_align_block.genomic_align_block_id HAVING count(*) > 3";
+								+ " AND conservation_score.genomic_align_block_id IS NULL GROUP BY genomic_align_block.genomic_align_block_id HAVING count(distinct(genome_db_id)) > 3";
 					} else {
 						useful_sql = "SELECT genomic_align_block.genomic_align_block_id FROM genomic_align_block LEFT JOIN conservation_score USING (genomic_align_block_id) LEFT JOIN genomic_align USING (genomic_align_block_id) LEFT JOIN dnafrag USING (dnafrag_id) WHERE genomic_align_block.method_link_species_set_id = "
 								+ msa_mlss_ids[1]
 								+ " AND conservation_score.genomic_align_block_id IS NULL AND genome_db_id <> "
 								+ ancestral_seq_id
-								+ " GROUP BY genomic_align_block.genomic_align_block_id HAVING count(*) > 3";
+								+ " GROUP BY genomic_align_block.genomic_align_block_id HAVING count(distinct(genome_db_id)) > 3";
 					}
 
 					String[] failures = DBUtils
@@ -107,20 +107,20 @@ public class CheckConservationScorePerBlock extends SingleDatabaseTestCase {
 						 * cow or dog and still not get above the min_rej_sub
 						 * score (default=0.5)
 						 */
-						String useful_sql4 = "SELECT genomic_align_block.genomic_align_block_id FROM genomic_align_block LEFT JOIN genomic_align USING (genomic_align_block_id) LEFT JOIN conservation_score USING (genomic_align_block_id) WHERE genomic_align_block.method_link_species_set_id = "
+						String useful_sql4 = "SELECT genomic_align_block.genomic_align_block_id FROM genomic_align_block LEFT JOIN genomic_align USING (genomic_align_block_id) LEFT JOIN conservation_score USING (genomic_align_block_id) JOIN dnafrag USING(dnafrag_id) WHERE genomic_align_block.method_link_species_set_id = "
 								+ msa_mlss_ids[1]
-								+ " AND conservation_score.genomic_align_block_id IS NULL GROUP BY genomic_align_block.genomic_align_block_id HAVING count(*) = 4";
+								+ " AND conservation_score.genomic_align_block_id IS NULL GROUP BY genomic_align_block.genomic_align_block_id HAVING count(distinct(genome_db_id)) > 3";
 						String[] failures4 = DBUtils.getColumnValues(con,
 								useful_sql4);
 						if (failures.length == failures4.length) {
 							ReportManager.problem(this, con, "WARNING conservation_score -> multiple alignments which have more than 3 species but don't have any conservation scores");
 							ReportManager.problem(this, con, "WARNING DETAILS: There are " + failures.length + " blocks (mlss= " + msa_mlss_ids[1]
-													+ ") with 4 seqs and no conservation score! Must check that the sum of the branch lengths of these 4 species is less than 0.5 (min_neu_evol). If it is greater than 0.5, there is a problem that needs fixing!");
+													+ ") with more than 3 species and no conservation score! Must check that the sum of the branch lengths of these 4+ species is less than 0.5 (min_neu_evol). If it is greater than 0.5, there is a problem that needs fixing!");
 							ReportManager.problem(this, con, "USEFUL SQL: " + useful_sql4);
 
 						} else {
 							ReportManager.problem(this, con, "FAILED conservation_score -> multiple alignments which have more than 3 species but don't have any conservation scores");
-							ReportManager.problem(this, con, "FAILURE DETAILS: There are " + failures.length + " blocks (mlss= " + msa_mlss_ids[1] + ") with more than 4 seqs and no conservation score!");
+							ReportManager.problem(this, con, "FAILURE DETAILS: There are " + failures.length + " blocks (mlss= " + msa_mlss_ids[1] + ") with more than 3 species and no conservation score!");
 							ReportManager.problem(this, con, "USEFUL SQL: " + useful_sql);
 							result = false;
 						}

--- a/src/org/ensembl/healthcheck/testcase/compara/MLSSTagHighCoverageMSA.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/MLSSTagHighCoverageMSA.java
@@ -33,7 +33,7 @@ import org.ensembl.healthcheck.testcase.SingleDatabaseTestCase;
 import org.ensembl.healthcheck.util.DBUtils;
 
 /**
- * An EnsEMBL Healthcheck test case for the "high_coverage_mlss_id" MethodLinkSpeciesSetTag entries
+ * An EnsEMBL Healthcheck test case for the "base_mlss_id" MethodLinkSpeciesSetTag entries
  */
 
 public class MLSSTagHighCoverageMSA extends SingleDatabaseTestCase {
@@ -64,7 +64,7 @@ public class MLSSTagHighCoverageMSA extends SingleDatabaseTestCase {
 		Connection con = dbre.getConnection();
 		String sql = "SELECT mlss1.method_link_species_set_id, tag, value, mlss2.method_link_species_set_id, ml2.type"
 			+ " FROM method_link_species_set mlss1 JOIN method_link ml1 USING (method_link_id)"
-			+ " LEFT JOIN method_link_species_set_tag mlsst ON mlsst.method_link_species_set_id = mlss1.method_link_species_set_id AND tag = 'high_coverage_mlss_id'"
+			+ " LEFT JOIN method_link_species_set_tag mlsst ON mlsst.method_link_species_set_id = mlss1.method_link_species_set_id AND tag = 'base_mlss_id'"
 			+ " LEFT JOIN (method_link_species_set mlss2 JOIN method_link ml2 USING (method_link_id)) ON value = mlss2.method_link_species_set_id"
 			+ " WHERE ml1.type = 'EPO_LOW_COVERAGE'";
 
@@ -73,15 +73,15 @@ public class MLSSTagHighCoverageMSA extends SingleDatabaseTestCase {
 		for (String[] row : all_rows) {
 			// Check all the potential errors
 			if (row[1] == null) {
-				ReportManager.problem(this, con, String.format("The MLSS ID %s is missing its 'high_coverage_mlss_id' tag", row[0]));
+				ReportManager.problem(this, con, String.format("The MLSS ID %s is missing its 'base_mlss_id' tag", row[0]));
 			} else if (row[2] == null) {
-				ReportManager.problem(this, con, String.format("The 'high_coverage_mlss_id' tag for MLSS ID %s has a NULL value", row[0]));
+				ReportManager.problem(this, con, String.format("The 'base_mlss_id' tag for MLSS ID %s has a NULL value", row[0]));
 			} else if (row[3] == null) {
-				ReportManager.problem(this, con, String.format("The value of the 'high_coverage_mlss_id' tag for MLSS ID %s does not link to a valid MLSS ID: '%s'", row[0], row[2]));
-			} else if (!row[4].equals("EPO")) {
-				ReportManager.problem(this, con, String.format("The value of the 'high_coverage_mlss_id' tag for MLSS ID %s does not link to a 'EPO' MLSS but '%s' (ID %s)", row[0], row[4], row[3]));
+				ReportManager.problem(this, con, String.format("The value of the 'base_mlss_id' tag for MLSS ID %s does not link to a valid MLSS ID: '%s'", row[0], row[2]));
+			} else if (!(row[4].equals("EPO") || row[4].equals("EPO_LOW_COVERAGE"))) {
+				ReportManager.problem(this, con, String.format("The value of the 'base_mlss_id' tag for MLSS ID %s does not link to an 'EPO' or 'EPO_LOW_COVERAGE' MLSS but '%s' (ID %s)", row[0], row[4], row[3]));
 			} else {
-				// This row is correct: everything is non-NULL, and the EPO_LOW_COVERAGE mlss is linked to a EPO
+				// This row is correct: everything is non-NULL, and the EPO_LOW_COVERAGE mlss is linked to an EPO or EPO_LOW_COVERAGE
 				continue;
 			}
 			result = false;

--- a/src/org/ensembl/healthcheck/testcase/compara/MLSSTagStatsMultipleAlignment.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/MLSSTagStatsMultipleAlignment.java
@@ -30,7 +30,7 @@ public class MLSSTagStatsMultipleAlignment extends AbstractMLSSTagStats {
 		};
 		mandatoryTags.put("EPO", tags_multiple_alignments);
 		mandatoryTags.put("PECAN", tags_multiple_alignments);
-		mandatoryTags.put("EPO_LOW_COVERAGE", tags_multiple_alignments);	// We don't include "high_coverage_mlss_id" because it is checked by another HC
+		mandatoryTags.put("EPO_LOW_COVERAGE", tags_multiple_alignments);	// We don't include "base_mlss_id" because it is checked by another HC
 
 		return mandatoryTags;
 	}


### PR DESCRIPTION
2 fixes for compara HCs:

1. CheckConservationScorePerBlock has been checking sequence counts. GERP only refuses to compute on <3 _species_, so the test should be checking species counts.
2. We have updated the `high_coverage_mlss_id` tag to `base_mlss_id` to reflect a new topup option - MLSSTagHighCoverageMSA should check for this tag instead.