### PR TITLE
Update ComparaPanIntegrity.java

### DIFF
--- a/src/org/ensembl/healthcheck/testgroup/ComparaPanIntegrity.java
+++ b/src/org/ensembl/healthcheck/testgroup/ComparaPanIntegrity.java
@@ -25,6 +25,7 @@ import org.ensembl.healthcheck.testcase.compara.MLSSTagStatsHomology;
 import org.ensembl.healthcheck.testcase.compara.MLSSTagThresholdDs;
 import org.ensembl.healthcheck.testcase.compara.ForeignKeyMasterTables;
 import org.ensembl.healthcheck.testcase.compara.CheckSpeciesSetSizeByMethod;
+import org.ensembl.healthcheck.testcase.compara.CheckOrthologQCThresholds;
 /**
  * Healthchecks for the genomic Compara databases
  * (and only this kind of database)

--- a/src/org/ensembl/healthcheck/testgroup/ComparaPanIntegrity.java
+++ b/src/org/ensembl/healthcheck/testgroup/ComparaPanIntegrity.java
@@ -37,6 +37,6 @@ public class ComparaPanIntegrity extends ComparaIntegrity {
 		addTest(
 			org.ensembl.healthcheck.testcase.eg_compara.ForeignKeyPanMasterTables.class
 		);
-		removeTest(CheckSynteny.class, CheckDuplicatedTaxaNames.class, CheckTopLevelDnaFrag.class, MLSSTagStatsHomology.class, MLSSTagThresholdDs.class, ForeignKeyMasterTables.class, CheckSpeciesSetSizeByMethod.class);
+		removeTest(CheckOrthologQCThresholds.class, CheckSynteny.class, CheckDuplicatedTaxaNames.class, CheckTopLevelDnaFrag.class, MLSSTagStatsHomology.class, MLSSTagThresholdDs.class, ForeignKeyMasterTables.class, CheckSpeciesSetSizeByMethod.class);
 	}
 }


### PR DESCRIPTION
there is no WGA or GOC data in Pan-Compara if you use the default parameters