### PR TITLE
Compara update for GRCh37 and Pan

### DIFF
--- a/README
+++ b/README
@@ -59,6 +59,8 @@ command-line options through to the ConfigurableTestRunner class.
 
         [--driver2 value]                  : Driver for server 2 (support for multiple staging servers in Ensembl)
 
+        [--driver3 value]                  : Driver for server 3 (support for multiple staging servers in Ensembl)
+
         [--endSession value]               : Flag to run an empty testrunnerUsed to mark the end of a parallel run
 
         [--exclude_groups -G value...]     : Specify which groups of tests should not be run. Fully qualified class names can be used as well as their short names.
@@ -76,6 +78,8 @@ command-line options through to the ConfigurableTestRunner class.
         [--host1 value]                    : Host for server 1 (support for multiple staging servers in Ensembl)
 
         [--host2 value]                    : Host for server 2 (support for multiple staging servers in Ensembl)
+
+        [--host3 value]                    : Host for server 3 (support for multiple staging servers in Ensembl)
 
         [--ignore.previous.checks value]   : Parameter used only in org.ensembl.healthcheck.testcase.generic.ComparePreviousVersionExonCoords, org.ensembl.healthcheck.testcase.generic.ComparePreviousVersionBase and org.ensembl.healthcheck.testcase.generic.GeneStatus
 
@@ -113,6 +117,8 @@ command-line options through to the ConfigurableTestRunner class.
 
         [--password2 value]                : Password for server 2 (support for multiple staging servers in Ensembl)
 
+        [--password3 value]                : Password for server 3 (support for multiple staging servers in Ensembl)
+
         [--perl value]                     : Parameter used only in org.ensembl.healthcheck.testcase.AbstractPerlBasedTestCase
 
         [--port -P value]                  : The port for the database server you wish to connect to.
@@ -120,6 +126,8 @@ command-line options through to the ConfigurableTestRunner class.
         [--port1 value]                    : Port for server 1 (support for multiple staging servers in Ensembl)
 
         [--port2 value]                    : Port for server 2 (support for multiple staging servers in Ensembl)
+
+        [--port3 value]                    : Port for server 3 (support for multiple staging servers in Ensembl)
 
         [--production.database value]      : The name of the Ensembl production database to use to retrieve division information. Assumed to be on the same server as the output databases.
 
@@ -160,6 +168,8 @@ command-line options through to the ConfigurableTestRunner class.
         [--user1 value]                    : User for server 1 (support for multiple staging servers in Ensembl)
 
         [--user2 value]                    : User for server 2 (support for multiple staging servers in Ensembl)
+
+        [--user3 value]                    : User for server 3 (support for multiple staging servers in Ensembl)
 
         [--variation_schema.file value]    : Parameter used only in org.ensembl.healthcheck.testcase.variation.CompareVariationSchema
 

--- a/database.defaults.properties
+++ b/database.defaults.properties
@@ -45,6 +45,11 @@ port2    = 4519
 user2    = ensro
 driver2  = org.gjt.mm.mysql.Driver
 
+#host3    = mysql-ens-sta-4
+#port3    = 4494
+#user3    = ensro
+#driver3  = org.gjt.mm.mysql.Driver
+
 #
 # Some tests require a second database. Configure the details of the database
 # server on which this should be found here.

--- a/src/org/ensembl/healthcheck/configuration/ConfigureHost.java
+++ b/src/org/ensembl/healthcheck/configuration/ConfigureHost.java
@@ -142,6 +142,31 @@ public interface ConfigureHost {
 
 	boolean isDriver2();
 
+	@Option(description = "Host for server 3 (support for multiple staging servers in Ensembl)")
+	String getHost3();
+
+	boolean isHost3();
+
+	@Option(description = "Port for server 3 (support for multiple staging servers in Ensembl)")
+	String getPort3();
+
+	boolean isPort3();
+
+	@Option(description = "User for server 3 (support for multiple staging servers in Ensembl)")
+	String getUser3();
+
+	boolean isUser3();
+
+	@Option(description = "Password for server 3 (support for multiple staging servers in Ensembl)")
+	String getPassword3();
+
+	boolean isPassword3();
+
+	@Option(description = "Driver for server 3 (support for multiple staging servers in Ensembl)")
+	String getDriver3();
+
+	boolean isDriver3();
+
 	@Option(longName = "release", description = "Release number which will apply once the data you're testing is released")
 	String getRelease();
 	boolean isRelease();

--- a/src/org/ensembl/healthcheck/testcase/compara/AbstractComparaTestCase.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/AbstractComparaTestCase.java
@@ -45,6 +45,37 @@ import org.ensembl.healthcheck.util.SqlUncheckedException;
 
 public abstract class AbstractComparaTestCase extends SingleDatabaseTestCase {
 
+	protected boolean checkMLSSIds(DatabaseRegistryEntry dbre, String[] method_link_species_set_ids) {
+		ReportManager.info(this, dbre.getConnection(), "No further testing done on the " . method_link_species_set_ids.length + " mlss_ids provided");
+		return true;
+	}
+
+	public boolean checkTableForMLSS(DatabaseRegistryEntry dbre, String mlss_filter, String table_name) {
+
+		Connection con = dbre.getConnection();
+
+		String[] method_link_species_set_ids = DBUtils.getColumnValues(con, "SELECT method_link_species_set_id FROM method_link_species_set JOIN method_link USING (method_link_id) WHERE " + mlss_filter);
+
+		if (method_link_species_set_ids.length > 0) {
+
+			if (!tableHasRows(con, table_name)) {
+				ReportManager.problem(this, con, "FAILED: Database contains entry in the method_link_species_set table but the " + table_name + " table is empty");
+				return false;
+			}
+
+			return checkMLSSIds(dbre, method_link_species_set_ids);
+
+		} else if (tableHasRows(con, table_name)) {
+			ReportManager.problem(this, con, "FAILED: Database contains data in the " + table_name + " table but no corresponding entry in the method_link_species_set table.");
+			return false;
+
+		} else {
+			ReportManager.correct(this, con, "Empty " + table_name);
+			return true;
+		}
+	}
+
+
 
 	/**
 	 * Verify foreign-key relations, and fills ReportManager with useful sql if

--- a/src/org/ensembl/healthcheck/testcase/compara/AbstractComparaTestCase.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/AbstractComparaTestCase.java
@@ -199,7 +199,7 @@ public abstract class AbstractComparaTestCase extends SingleDatabaseTestCase {
 					String sql = "SELECT meta_value FROM meta WHERE meta_key = \"species.production_name\" AND species_id = " + species_id;
 					String production_name = DBUtils.getRowColumnValue(entry.getConnection(), sql);
 					speciesCoreMap.put(production_name, new Pair<DatabaseRegistryEntry,Integer>(entry,species_id));
-					ReportManager.info(this, comparaDbre.getConnection(), entry.toString() + " == " + production_name + " (" + species_id + ")");
+					//ReportManager.info(this, comparaDbre.getConnection(), entry.toString() + " == " + production_name + " (" + species_id + ")");
 				}
 				try {
 					entry.getConnection().close();

--- a/src/org/ensembl/healthcheck/testcase/compara/AbstractComparaTestCase.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/AbstractComparaTestCase.java
@@ -46,7 +46,7 @@ import org.ensembl.healthcheck.util.SqlUncheckedException;
 public abstract class AbstractComparaTestCase extends SingleDatabaseTestCase {
 
 	protected boolean checkMLSSIds(DatabaseRegistryEntry dbre, String[] method_link_species_set_ids) {
-		ReportManager.info(this, dbre.getConnection(), "No further testing done on the " . method_link_species_set_ids.length + " mlss_ids provided");
+		ReportManager.info(this, dbre.getConnection(), "No further testing done on the " + method_link_species_set_ids.length + " mlss_ids provided");
 		return true;
 	}
 

--- a/src/org/ensembl/healthcheck/testcase/compara/CheckConservationScore.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/CheckConservationScore.java
@@ -30,7 +30,7 @@ import org.ensembl.healthcheck.util.DBUtils;
  * An EnsEMBL Healthcheck test case that checks the conservation_score table
  */
 
-public class CheckConservationScore extends SingleDatabaseTestCase {
+public class CheckConservationScore extends AbstractComparaTestCase {
 
 	/**
 	 * Create an CheckConservationScore that applies to a specific set of
@@ -50,24 +50,16 @@ public class CheckConservationScore extends SingleDatabaseTestCase {
 	 * 
 	 */
 	public boolean run(DatabaseRegistryEntry dbre) {
+		return checkTableForMLSS(
+				dbre,
+				"type=\"GERP_CONSERVATION_SCORE\" OR class LIKE \"ConservationScore%\"",
+				"conservation_score"
+				);
+	}
+
+	public boolean checkMLSSIds(DatabaseRegistryEntry dbre, String[] method_link_species_set_ids) {
 
 		Connection con = dbre.getConnection();
-
-		/**
-		 * Get all method_link_species_set_ids for method_link type of
-		 * GERP_CONSERVATION_SCORE
-		 */
-		String[] method_link_species_set_ids = DBUtils.getColumnValues(con, "SELECT method_link_species_set_id FROM method_link_species_set LEFT JOIN method_link USING (method_link_id) WHERE type=\"GERP_CONSERVATION_SCORE\" OR class LIKE \"ConservationScore%\"");
-
-		if (method_link_species_set_ids.length > 0) {
-
-			/**
-			 * Check have entries in conservation_score table
-			 */
-			if (!tableHasRows(con, "conservation_score")) {
-				ReportManager.problem(this, con, "FAILED: Database contains entry in the method_link_species_set table but the conservation_score table is empty");
-				return false;
-			}
 
 			boolean result = true;
 			for(String mlss_id : method_link_species_set_ids) {
@@ -89,15 +81,6 @@ public class CheckConservationScore extends SingleDatabaseTestCase {
 			}
 
 			return result;
-
-		} else if (tableHasRows(con, "conservation_score")) {
-			ReportManager.problem(this, con, "FAILED: Database contains data in the conservation_score table but no corresponding entry in the method_link_species_set table.");
-			return false;
-
-		} else {
-			ReportManager.correct(this, con, "NO conservation scores in this database");
-			return true;
-		}
 	}
 
 } // CheckConservationScore

--- a/src/org/ensembl/healthcheck/testcase/compara/CheckGenomicAlignGenomeDBs.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/CheckGenomicAlignGenomeDBs.java
@@ -53,39 +53,20 @@ public class CheckGenomicAlignGenomeDBs extends AbstractComparaTestCase {
 	 * 
 	 */
 	public boolean run(DatabaseRegistryEntry dbre) {
+		return checkTableForMLSS(
+				dbre,
+				"class LIKE \"GenomicAlign%\" AND type NOT LIKE \"CACTUS_HAL%\"",
+				"genomic_align_block"
+				);
+	}
+
+	public boolean checkMLSSIds(DatabaseRegistryEntry dbre, String[] method_link_species_set_ids) {
 
 		boolean result = true;
 
 		Connection con = dbre.getConnection();
 
-		/**
-		 * Check have entries in the genomic_align table
-		 */
-		if (!tableHasRows(con, "genomic_align")) {
-			ReportManager.problem(this, con,
-					"No entries in the genomic_align table");
-			return result;
-		}
-		if (!tableHasRows(con, "genomic_align_block")) {
-			ReportManager.problem(this, con,
-					"No entries in the genomic_align_block table");
-			return result;
-		}
-		if (!tableHasRows(con, "method_link_species_set")) {
-			ReportManager.problem(this, con,
-					"No entries in the method_link_species_set table");
-			return result;
-		}
-		/**
-		 * Get all method_link_species_set_ids for genomic_align_blocks
-		 */
-		String[] method_link_species_set_ids = DBUtils
-				.getColumnValues(con,
-						"SELECT distinct(method_link_species_set_id) FROM genomic_align_block");
-
 		String ancestral_gdb_id = DBUtils.getRowColumnValue(con, "SELECT genome_db_id FROM genome_db WHERE name = \"ancestral_sequences\"");
-
-		if (method_link_species_set_ids.length > 0) {
 
 			for (String mlss_id : method_link_species_set_ids) {
 
@@ -136,7 +117,6 @@ public class CheckGenomicAlignGenomeDBs extends AbstractComparaTestCase {
 					result = false;
 				}
 			}
-		}
 
 		return result;
 	}

--- a/src/org/ensembl/healthcheck/testcase/compara/CheckOrthologQCThresholds.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/CheckOrthologQCThresholds.java
@@ -24,6 +24,7 @@ import org.ensembl.healthcheck.DatabaseRegistryEntry;
 import org.ensembl.healthcheck.ReportManager;
 import org.ensembl.healthcheck.Team;
 import org.ensembl.healthcheck.testcase.SingleDatabaseTestCase;
+import org.ensembl.healthcheck.util.DBUtils;
 
 /**
  * An EnsEMBL Healthcheck test case that checks that
@@ -41,8 +42,15 @@ public class CheckOrthologQCThresholds extends SingleDatabaseTestCase {
 		Connection con = dbre.getConnection();
 
 		boolean result = true;
-		result &= checkCountIsNonZero(con, "method_link_species_set_attr", "goc_quality_threshold IS NOT NULL");
-		result &= checkCountIsNonZero(con, "method_link_species_set_attr", "wga_quality_threshold IS NOT NULL");
+
+		int numOrthologyMLSS = DBUtils.getRowCount(con, "SELECT COUNT(*) FROM method_link_species_set JOIN method_link USING (method_link_id) WHERE type = 'ENSEMBL_ORTHOLOGUES'");
+		if (numOrthologyMLSS > 0) {
+			result &= checkCountIsNonZero(con, "method_link_species_set_attr", "goc_quality_threshold IS NOT NULL");
+			result &= checkCountIsNonZero(con, "method_link_species_set_attr", "wga_quality_threshold IS NOT NULL");
+		} else {
+			result &= checkCountIsZero(con, "method_link_species_set_attr", "goc_quality_threshold IS NOT NULL");
+			result &= checkCountIsZero(con, "method_link_species_set_attr", "wga_quality_threshold IS NOT NULL");
+		}
 		return result;
 	}
 

--- a/src/org/ensembl/healthcheck/testcase/compara/CheckSynteny.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/CheckSynteny.java
@@ -31,7 +31,7 @@ import org.ensembl.healthcheck.util.DBUtils;
  * relationships.
  */
 
-public class CheckSynteny extends SingleDatabaseTestCase {
+public class CheckSynteny extends AbstractComparaTestCase {
 
 	/**
 	 * Create an CheckSynteny that applies to a specific set of databases.
@@ -50,23 +50,20 @@ public class CheckSynteny extends SingleDatabaseTestCase {
 	 * 
 	 */
 	public boolean run(DatabaseRegistryEntry dbre) {
+		return checkTableForMLSS(
+				dbre,
+				"type=\"SYNTENY\" OR class LIKE \"SyntenyRegion%\"",
+				"synteny_region"
+				);
+	}
+
+	public boolean checkMLSSIds(DatabaseRegistryEntry dbre, String[] method_link_species_set_ids) {
 
 		Connection con = dbre.getConnection();
 
-		if (!tableHasRows(con, "synteny_region")) {
-			ReportManager.problem(this, con, "NO ENTRIES in the synteny_region table");
-			return false;
-		} else if (!tableHasRows(con, "dnafrag_region")) {
-			ReportManager.problem(this, con, "NO ENTRIES in the dnafrag_region table");
-			return false;
-		} else if (!tableHasRows(con, "dnafrag")) {
-			ReportManager.problem(this, con, "NO ENTRIES in the dnafrag table");
-			return false;
-		} else {
 			boolean result = true;
 			result &= checkForSingles(con, "dnafrag_region", "synteny_region_id");
 			return result;
-		}
 	}
 
-} // CheckHomology
+} // CheckSynteny

--- a/src/org/ensembl/healthcheck/testcase/compara/CheckSyntenySanity.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/CheckSyntenySanity.java
@@ -57,19 +57,9 @@ public class CheckSyntenySanity extends SingleDatabaseTestCase {
 
 		Connection con = dbre.getConnection();
 
-		if (!tableHasRows(con, "synteny_region")) {
-			ReportManager.problem(this, con,
-					"NO ENTRIES in the synteny_region table");
-		} else if (!tableHasRows(con, "dnafrag_region")) {
-			ReportManager.problem(this, con,
-					"NO ENTRIES in the dnafrag_region table");
-		} else if (!tableHasRows(con, "dnafrag")) {
-			ReportManager.problem(this, con, "NO ENTRIES in the dnafrag table");
-		} else {
 			for (String this_mlss_id : get_all_method_link_species_set_ids(con)) {
 				result &= check_this_synteny(con, this_mlss_id);
 			}
-		}
 
 		return result;
 

--- a/src/org/ensembl/healthcheck/testcase/compara/MLSSTagThresholdDs.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/MLSSTagThresholdDs.java
@@ -24,6 +24,7 @@ import org.ensembl.healthcheck.DatabaseRegistryEntry;
 import org.ensembl.healthcheck.ReportManager;
 import org.ensembl.healthcheck.Team;
 import org.ensembl.healthcheck.testcase.SingleDatabaseTestCase;
+import org.ensembl.healthcheck.util.DBUtils;
 
 /**
  * An EnsEMBL Healthcheck test case to check for "threshold_on_ds" in the
@@ -47,8 +48,13 @@ public class MLSSTagThresholdDs extends SingleDatabaseTestCase {
 		}
 
 		boolean result = true;
-		result &= checkCountIsNonZero(con, "method_link_species_set_attr", "threshold_on_ds IS NOT NULL");
-		result &= checkCountIsZero(con, "method_link_species_set_attr", "(threshold_on_ds IS NOT NULL) AND (threshold_on_ds NOT IN (1,2))");
+		int dndsCount = Integer.valueOf(DBUtils.getRowColumnValue(con, "SELECT COUNT(*) FROM (SELECT ds FROM homology WHERE ds IS NOT NULL LIMIT 1) _t")).intValue();
+		if (dndsCount > 0) {
+			result &= checkCountIsNonZero(con, "method_link_species_set_attr", "threshold_on_ds IS NOT NULL");
+			result &= checkCountIsZero(con, "method_link_species_set_attr", "(threshold_on_ds IS NOT NULL) AND (threshold_on_ds NOT IN (1,2))");
+		} else {
+			result &= checkCountIsZero(con, "method_link_species_set_attr", "threshold_on_ds IS NOT NULL");
+		}
 		return result;
 	}
 

--- a/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
@@ -111,11 +111,22 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 		 * Check that the table is not empty
 		 */
 
-		if ((hasFamilies || hasGeneTrees) && (counts[0] == null)) {
-			ReportManager.problem(this, con, "Found no entries in gene_member_hom_stats for the " + collection + " collection. There should be some");
-			return false;
+		boolean shouldBeNonEmpty = false;
+		for (boolean e: expectNonEmpty) {
+			shouldBeNonEmpty |= e;
 		}
 
+		if (shouldBeNonEmpty) {
+			if (counts[0] == null) {
+				ReportManager.problem(this, con, "Found no entries in gene_member_hom_stats " + filterDescription + ". There should be some");
+				return false;
+			}
+		} else {
+			if (counts[0] != null) {
+				ReportManager.problem(this, con, "Found entries in gene_member_hom_stats " + filterDescription + ". There shouldn't be any");
+				return false;
+			}
+		}
 
 		/*
 		 * Check every column independently

--- a/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
@@ -3,18 +3,19 @@ package org.ensembl.healthcheck.testcase.compara;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.Arrays;
 import java.util.List;
 
 import org.ensembl.healthcheck.DatabaseRegistryEntry;
 import org.ensembl.healthcheck.DatabaseType;
 import org.ensembl.healthcheck.ReportManager;
 import org.ensembl.healthcheck.Team;
-import org.ensembl.healthcheck.testcase.AbstractTemplatedTestCase;
+import org.ensembl.healthcheck.testcase.compara.AbstractComparaTestCase;
 import org.ensembl.healthcheck.util.DBUtils;
 import org.ensembl.healthcheck.util.SqlTemplate;
 import org.ensembl.healthcheck.util.SqlUncheckedException;
 
-public class MemberProductionCounts extends AbstractTemplatedTestCase {
+public class MemberProductionCounts extends AbstractComparaTestCase {
 
 	public MemberProductionCounts() {
 		setTeamResponsible(Team.COMPARA);
@@ -22,14 +23,39 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 		setDescription("Checks whether gene member counts have been populated");
 	}
 
-	@Override
-	protected boolean runTest(DatabaseRegistryEntry dbre) {
+	public boolean run(DatabaseRegistryEntry dbre) {
 
-		// All the possible collection names
-		List<String> allCollectionNames = DBUtils.getColumnValuesList(dbre.getConnection(), "SELECT DISTINCT clusterset_id FROM gene_tree_root WHERE tree_type = \"tree\" AND ref_root_id IS NULL");
 
 		boolean result = true;
 
+		if (getComparaDivisionName(dbre).equals("grch37")) {
+
+			// There are no gene-trees so we need to manually set the collection name here
+			List<String> allCollectionNames = Arrays.asList("default");
+			result &= compareCollectionNames(dbre, allCollectionNames);
+
+			// The automatic detection doesn't allow homolgies in the absence of gene-trees
+			boolean[] expectNonEmpty = {false, false, false, false, true, false};
+			result &= runComparison(dbre, "1", "(GRCh37)", expectNonEmpty);
+
+		} else {
+
+			// All the possible collection names
+			List<String> allCollectionNames = DBUtils.getColumnValuesList(dbre.getConnection(), "SELECT DISTINCT clusterset_id FROM gene_tree_root WHERE tree_type = \"tree\" AND ref_root_id IS NULL");
+			result &= compareCollectionNames(dbre, allCollectionNames);
+
+			// Check the counts for each collection name
+			for (String collection : allCollectionNames) {
+				boolean[] expectNonEmpty = getExpectationForCollection(dbre, collection);
+				result &= runComparison(dbre, "collection = \"" + collection + "\"", "for the " + collection + " collection", expectNonEmpty);
+			}
+		}
+
+		return result;
+	}
+
+	public boolean compareCollectionNames(DatabaseRegistryEntry dbre, List<String> allCollectionNames) {
+		boolean result = true;
 		// Check that there are no other collection names in gene_member_hom_stats
 		for (String collection : DBUtils.getColumnValuesList(dbre.getConnection(), "SELECT DISTINCT collection FROM gene_member_hom_stats")) {
 			if (!allCollectionNames.contains(collection)) {
@@ -37,12 +63,6 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 				ReportManager.problem(this, dbre.getConnection(), "Found entries in gene_member_hom_stats for the " + collection + " collection but there isn't any data attached to it");
 			}
 		}
-
-		// Check the counts for each collection name
-		for (String collection : allCollectionNames) {
-			result &= checkCountsForCollection(dbre, collection);
-		}
-
 		return result;
 	}
 
@@ -79,9 +99,8 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 	}
 
 
-	private boolean checkCountsForCollection(DatabaseRegistryEntry dbre, String collection) {
+	private boolean[] getExpectationForCollection(DatabaseRegistryEntry dbre, String collection) {
 		SqlTemplate srv = getSqlTemplate(dbre);
-		Connection con  = dbre.getConnection();
 
 		/*
 		 * Check which data tables have actually been populated for that collection
@@ -92,20 +111,27 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 		String sqlGeneTrees   = "SELECT COUNT(*) FROM gene_tree_root WHERE clusterset_id = \"" + collection + "\"";
 		String sqlPolyploids  = "SELECT COUNT(*) FROM genome_db WHERE genome_component IS NOT NULL";  // NOTE: assumes that the polyploid genomes are found in all the collections
 		String sqlCAFETrees   = "SELECT COUNT(*) FROM gene_tree_root JOIN CAFE_gene_family ON gene_tree_root.root_id = gene_tree_root_id WHERE clusterset_id = \"" + collection + "\"";
+
 		// Which columns should have non-zero counts
 		boolean hasFamilies   = collection.equals("default") && (srv.queryForDefaultObject(sqlFamilies, Integer.class) > 0);  // ... so we record families in the "default" collection
 		boolean hasGeneTrees  = srv.queryForDefaultObject(sqlGeneTrees, Integer.class) > 0;
 		boolean hasPolyploids = srv.queryForDefaultObject(sqlPolyploids, Integer.class) > 0;
 		boolean hasCAFETrees  = srv.queryForDefaultObject(sqlCAFETrees, Integer.class) > 0;
 
-		// NOTE: keep "headers" in sync with the columns used in SUM
-		String[] headers = {"families", "gene_trees", "gene_gain_loss_trees", "orthologues", "paralogues", "homoeologues"};
-		String sqlCounts = "SELECT SUM(families), SUM(gene_trees), SUM(gene_gain_loss_trees), SUM(orthologues), SUM(paralogues), SUM(homoeologues) FROM gene_member_hom_stats WHERE collection = \"" + collection + "\"";
-		Integer[] counts = getFirstRowAsIntegers(con, sqlCounts);
-
 		// Which counts should be non-zero
 		boolean[] expectNonEmpty = {hasFamilies, hasGeneTrees, hasCAFETrees, hasGeneTrees, hasGeneTrees, hasGeneTrees && hasPolyploids};
+		return expectNonEmpty;
+	}
 
+
+	private boolean runComparison(DatabaseRegistryEntry dbre, String filterSQL, String filterDescription, boolean[] expectNonEmpty) {
+		SqlTemplate srv = getSqlTemplate(dbre);
+		Connection con  = dbre.getConnection();
+
+		// NOTE: keep "headers" in sync with the columns used in SUM
+		String[] headers = {"families", "gene_trees", "gene_gain_loss_trees", "orthologues", "paralogues", "homoeologues"};
+		String sqlCounts = "SELECT SUM(families), SUM(gene_trees), SUM(gene_gain_loss_trees), SUM(orthologues), SUM(paralogues), SUM(homoeologues) FROM gene_member_hom_stats WHERE " + filterSQL;
+		Integer[] counts = getFirstRowAsIntegers(con, sqlCounts);
 
 		/*
 		 * Check that the table is not empty
@@ -136,10 +162,10 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 		for (int i=0; i<headers.length; i++) {
 			// Compare the zeroness of the count to the expectation
 			if (expectNonEmpty[i] && (counts[i] == 0)) {
-				ReportManager.problem(this, con, "Found no entries in gene_member_hom_stats with " + headers[i] + " > 0 for the " + collection + " collection. There should be some");
+				ReportManager.problem(this, con, "Found no entries in gene_member_hom_stats with " + headers[i] + " > 0 " + filterDescription + ". There should be some");
 				result = false;
 			} else if (!expectNonEmpty[i] && (counts[i] > 0)) {
-				ReportManager.problem(this, con, "Found entries in gene_member_hom_stats with " + headers[i] + " > 0 for the " + collection + " collection. There shouldn't be any");
+				ReportManager.problem(this, con, "Found entries in gene_member_hom_stats with " + headers[i] + " > 0 " + filterDescription + ". There shouldn't be any");
 				result = false;
 			}
 		}
@@ -151,18 +177,18 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 
 		if (expectNonEmpty[1]) { // gene_trees flag
 			// Where there are homologues, there must be a gene-tree
-			String sqlBrokenHomologyCounts  = "SELECT COUNT(*) FROM gene_member_hom_stats WHERE gene_trees = 0 AND (orthologues > 0 OR paralogues > 0 OR homoeologues > 0) AND collection = '" + collection + "'";
+			String sqlBrokenHomologyCounts  = "SELECT COUNT(*) FROM gene_member_hom_stats WHERE gene_trees = 0 AND (orthologues > 0 OR paralogues > 0 OR homoeologues > 0) AND " + filterSQL;
 			Integer numBrokenHomologyCounts = srv.queryForDefaultObject(sqlBrokenHomologyCounts, Integer.class);
 			if (numBrokenHomologyCounts > 0) {
-				ReportManager.problem(this, con, "Found " + numBrokenHomologyCounts + " rows the collection " + collection + " where there are homologues without gene_trees");
+				ReportManager.problem(this, con, "Found " + numBrokenHomologyCounts + " rows " + filterDescription + " where there are homologues without gene_trees");
 				result = false;
 			}
 
 			// Where there is a CAFE tree, there must be a gene-tree
-			String sqlBrokenCAFEcounts  = "SELECT COUNT(*) FROM gene_member_hom_stats WHERE gene_trees = 0 AND gene_gain_loss_trees > 0 AND collection = '" + collection + "'";
+			String sqlBrokenCAFEcounts  = "SELECT COUNT(*) FROM gene_member_hom_stats WHERE gene_trees = 0 AND gene_gain_loss_trees > 0 AND " + filterSQL;
 			Integer numBrokenCAFEcounts = srv.queryForDefaultObject(sqlBrokenCAFEcounts, Integer.class);
 			if (numBrokenCAFEcounts > 0) {
-				ReportManager.problem(this, con, "Found " + numBrokenCAFEcounts + " rows for the collection " + collection + " where there are gene_gain_loss_trees without gene_trees");
+				ReportManager.problem(this, con, "Found " + numBrokenCAFEcounts + " rows " + filterDescription + " where there are gene_gain_loss_trees without gene_trees");
 				result = false;
 			}
 		}
@@ -175,11 +201,11 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 		// gene_trees
 		result &= checkCountIsZero(con,
 				"gene_member_hom_stats JOIN gene_member USING (gene_member_id) LEFT JOIN gene_tree_node ON canonical_member_id = seq_member_id",
-				"node_id IS NULL AND gene_trees > 0 AND collection = '" + collection + "'"
+				"node_id IS NULL AND gene_trees > 0 AND " + filterSQL
 				);
 		result &= checkCountIsZero(con,
 				"gene_member_hom_stats JOIN gene_member USING (gene_member_id) JOIN gene_tree_node ON canonical_member_id = seq_member_id JOIN gene_tree_root USING (root_id)",
-				"gene_trees = 0 AND collection = clusterset_id AND collection = '" + collection + "'"
+				"gene_trees = 0 AND collection = clusterset_id AND " + filterSQL
 				);
 
 		return result;

--- a/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
@@ -149,20 +149,22 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 		 * Check the dependencies between columns
 		 */
 
-		// Where there are homologues, there must be a gene-tree
-		String sqlBrokenHomologyCounts  = "SELECT COUNT(*) FROM gene_member_hom_stats WHERE gene_trees = 0 AND (orthologues > 0 OR paralogues > 0 OR homoeologues > 0) AND collection = '" + collection + "'";
-		Integer numBrokenHomologyCounts = srv.queryForDefaultObject(sqlBrokenHomologyCounts, Integer.class);
-		if (numBrokenHomologyCounts > 0) {
-			ReportManager.problem(this, con, "Found " + numBrokenHomologyCounts + " rows the collection " + collection + " where there are homologues without gene_trees");
-			result = false;
-		}
+		if (expectNonEmpty[1]) { // gene_trees flag
+			// Where there are homologues, there must be a gene-tree
+			String sqlBrokenHomologyCounts  = "SELECT COUNT(*) FROM gene_member_hom_stats WHERE gene_trees = 0 AND (orthologues > 0 OR paralogues > 0 OR homoeologues > 0) AND collection = '" + collection + "'";
+			Integer numBrokenHomologyCounts = srv.queryForDefaultObject(sqlBrokenHomologyCounts, Integer.class);
+			if (numBrokenHomologyCounts > 0) {
+				ReportManager.problem(this, con, "Found " + numBrokenHomologyCounts + " rows the collection " + collection + " where there are homologues without gene_trees");
+				result = false;
+			}
 
-		// Where there is a CAFE tree, there must be a gene-tree
-		String sqlBrokenCAFEcounts  = "SELECT COUNT(*) FROM gene_member_hom_stats WHERE gene_trees = 0 AND gene_gain_loss_trees > 0 AND collection = '" + collection + "'";
-		Integer numBrokenCAFEcounts = srv.queryForDefaultObject(sqlBrokenCAFEcounts, Integer.class);
-		if (numBrokenCAFEcounts > 0) {
-			ReportManager.problem(this, con, "Found " + numBrokenCAFEcounts + " rows for the collection " + collection + " where there are gene_gain_loss_trees without gene_trees");
-			result = false;
+			// Where there is a CAFE tree, there must be a gene-tree
+			String sqlBrokenCAFEcounts  = "SELECT COUNT(*) FROM gene_member_hom_stats WHERE gene_trees = 0 AND gene_gain_loss_trees > 0 AND collection = '" + collection + "'";
+			Integer numBrokenCAFEcounts = srv.queryForDefaultObject(sqlBrokenCAFEcounts, Integer.class);
+			if (numBrokenCAFEcounts > 0) {
+				ReportManager.problem(this, con, "Found " + numBrokenCAFEcounts + " rows for the collection " + collection + " where there are gene_gain_loss_trees without gene_trees");
+				result = false;
+			}
 		}
 
 

--- a/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
@@ -34,7 +34,7 @@ public class MemberProductionCounts extends AbstractComparaTestCase {
 			List<String> allCollectionNames = Arrays.asList("default");
 			result &= compareCollectionNames(dbre, allCollectionNames);
 
-			// The automatic detection doesn't allow homolgies in the absence of gene-trees
+			// The automatic detection doesn't allow homologies in the absence of gene-trees
 			boolean[] expectNonEmpty = {false, false, false, false, true, false};
 			result &= runComparison(dbre, "1", "(GRCh37)", expectNonEmpty);
 

--- a/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/MemberProductionCounts.java
@@ -101,7 +101,7 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 		// NOTE: keep "headers" in sync with the columns used in SUM
 		String[] headers = {"families", "gene_trees", "gene_gain_loss_trees", "orthologues", "paralogues", "homoeologues"};
 		String sqlCounts = "SELECT SUM(families), SUM(gene_trees), SUM(gene_gain_loss_trees), SUM(orthologues), SUM(paralogues), SUM(homoeologues) FROM gene_member_hom_stats WHERE collection = \"" + collection + "\"";
-		Integer[] counts = getFirstRowAsIntegers(dbre.getConnection(), sqlCounts);
+		Integer[] counts = getFirstRowAsIntegers(con, sqlCounts);
 
 		// Which counts should be non-zero
 		boolean[] expectNonEmpty = {hasFamilies, hasGeneTrees, hasCAFETrees, hasGeneTrees, hasGeneTrees, hasGeneTrees && hasPolyploids};
@@ -112,7 +112,7 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 		 */
 
 		if ((hasFamilies || hasGeneTrees) && (counts[0] == null)) {
-			ReportManager.problem(this, dbre.getConnection(), "Found no entries in gene_member_hom_stats for the " + collection + " collection. There should be some");
+			ReportManager.problem(this, con, "Found no entries in gene_member_hom_stats for the " + collection + " collection. There should be some");
 			return false;
 		}
 
@@ -125,10 +125,10 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 		for (int i=0; i<headers.length; i++) {
 			// Compare the zeroness of the count to the expectation
 			if (expectNonEmpty[i] && (counts[i] == 0)) {
-				ReportManager.problem(this, dbre.getConnection(), "Found no entries in gene_member_hom_stats with " + headers[i] + " > 0 for the " + collection + " collection. There should be some");
+				ReportManager.problem(this, con, "Found no entries in gene_member_hom_stats with " + headers[i] + " > 0 for the " + collection + " collection. There should be some");
 				result = false;
 			} else if (!expectNonEmpty[i] && (counts[i] > 0)) {
-				ReportManager.problem(this, dbre.getConnection(), "Found entries in gene_member_hom_stats with " + headers[i] + " > 0 for the " + collection + " collection. There shouldn't be any");
+				ReportManager.problem(this, con, "Found entries in gene_member_hom_stats with " + headers[i] + " > 0 for the " + collection + " collection. There shouldn't be any");
 				result = false;
 			}
 		}
@@ -142,7 +142,7 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 		String sqlBrokenHomologyCounts  = "SELECT COUNT(*) FROM gene_member_hom_stats WHERE gene_trees = 0 AND (orthologues > 0 OR paralogues > 0 OR homoeologues > 0) AND collection = '" + collection + "'";
 		Integer numBrokenHomologyCounts = srv.queryForDefaultObject(sqlBrokenHomologyCounts, Integer.class);
 		if (numBrokenHomologyCounts > 0) {
-			ReportManager.problem(this, dbre.getConnection(), "Found " + numBrokenHomologyCounts + " rows the collection " + collection + " where there are homologues without gene_trees");
+			ReportManager.problem(this, con, "Found " + numBrokenHomologyCounts + " rows the collection " + collection + " where there are homologues without gene_trees");
 			result = false;
 		}
 
@@ -150,7 +150,7 @@ public class MemberProductionCounts extends AbstractTemplatedTestCase {
 		String sqlBrokenCAFEcounts  = "SELECT COUNT(*) FROM gene_member_hom_stats WHERE gene_trees = 0 AND gene_gain_loss_trees > 0 AND collection = '" + collection + "'";
 		Integer numBrokenCAFEcounts = srv.queryForDefaultObject(sqlBrokenCAFEcounts, Integer.class);
 		if (numBrokenCAFEcounts > 0) {
-			ReportManager.problem(this, dbre.getConnection(), "Found " + numBrokenCAFEcounts + " rows for the collection " + collection + " where there are gene_gain_loss_trees without gene_trees");
+			ReportManager.problem(this, con, "Found " + numBrokenCAFEcounts + " rows for the collection " + collection + " where there are gene_gain_loss_trees without gene_trees");
 			result = false;
 		}
 

--- a/src/org/ensembl/healthcheck/testcase/compara/MultipleGenomicAlignBlockIds.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/MultipleGenomicAlignBlockIds.java
@@ -33,7 +33,7 @@ import org.ensembl.healthcheck.util.DBUtils;
  * relationships.
  */
 
-public class MultipleGenomicAlignBlockIds extends SingleDatabaseTestCase {
+public class MultipleGenomicAlignBlockIds extends AbstractComparaTestCase {
 
 	public MultipleGenomicAlignBlockIds() {
 		setDescription("Check that every genomic_align_block_id is linked to more than one single genomic_align_id.");
@@ -41,24 +41,23 @@ public class MultipleGenomicAlignBlockIds extends SingleDatabaseTestCase {
 	}
 
 	public boolean run(DatabaseRegistryEntry dbre) {
+		return checkTableForMLSS(
+				dbre,
+				// The test does not apply to EPO alignments because they store ancestral sequences in a different genomic_align_block_id
+				"class LIKE 'GenomicAlign%' AND class != 'GenomicAlignTree.ancestral_alignment'",
+				"genomic_align"
+				);
+	}
+
+	public boolean checkMLSSIds(DatabaseRegistryEntry dbre, String[] method_link_species_set_ids) {
 
 		boolean result = true;
 
 		Connection con = dbre.getConnection();
 
-		if (tableHasRows(con, "genomic_align")) {
-
-			// The test does not apply to EPO alignments because they store
-			// ancestral sequences in a different genomic_align_block_id
-			String sqlNonEPOmlss_ids = "SELECT method_link_species_set_id FROM method_link_species_set JOIN method_link USING (method_link_id) WHERE class LIKE 'GenomicAlign%' AND class != 'GenomicAlignTree.ancestral_alignment'";
-			String[] nonEPOmlss_ids = DBUtils.getColumnValues(con, sqlNonEPOmlss_ids);
-			for (String mlss_id : nonEPOmlss_ids) {
+			for (String mlss_id : method_link_species_set_ids) {
 				result &= checkForSinglesWithConstraint(con, "genomic_align", "genomic_align_block_id", "WHERE method_link_species_set_id = " + mlss_id);
 			}
-
-		} else {
-			ReportManager.correct(this, con, "NO ENTRIES in genomic_align table, so nothing to test IGNORED");
-		}
 
 		return result;
 

--- a/src/org/ensembl/healthcheck/util/DBUtils.java
+++ b/src/org/ensembl/healthcheck/util/DBUtils.java
@@ -990,6 +990,7 @@ public final class DBUtils {
             checkAndAddDatabaseServer(mainDatabaseServers, "host", "port", "user", "password", "driver");
             checkAndAddDatabaseServer(mainDatabaseServers, "host1", "port1", "user1", "password1", "driver1");
             checkAndAddDatabaseServer(mainDatabaseServers, "host2", "port2", "user2", "password2", "driver2");
+            checkAndAddDatabaseServer(mainDatabaseServers, "host3", "port3", "user3", "password3", "driver3");
         }
 
         logger.fine("Number of main database servers found: " + mainDatabaseServers.size());
@@ -1052,6 +1053,19 @@ public final class DBUtils {
                 checkAndAddDatabaseServerConf(mainDatabaseServers, hostConfiguration.getHost2(),
                         hostConfiguration.getPort2(), hostConfiguration.getUser2(), password,
                         hostConfiguration.getDriver2());
+            }
+
+            if (hostConfiguration.isHost3() && hostConfiguration.isPort3() && hostConfiguration.isUser3()) {
+
+                String password = null;
+
+                if (hostConfiguration.isPassword3()) {
+                    password = hostConfiguration.getPassword3();
+                }
+
+                checkAndAddDatabaseServerConf(mainDatabaseServers, hostConfiguration.getHost3(),
+                        hostConfiguration.getPort3(), hostConfiguration.getUser3(), password,
+                        hostConfiguration.getDriver3());
             }
         }
         return mainDatabaseServers;


### PR DESCRIPTION
Here is a bunch of updates to make the HCs accept the GRCh37 and Pan databases. In most cases, the change consists in detecting whether there should be data or not, and only running the tests if there should.

The main exception is MemberProductionCounts, that I can't make accept GRCh37 without breaking fundamental assumptions. Instead I hardcoded what to expect in the case of GRCh37.

My goal is to be able to run ComparaAll (ComparaIntegrity) on Pan too instead of ComparaPanIntegrity. There are still a few failures on their e100 database which I hope will be able to fix during e101 production. Once confirmed I'll submit another PR to remove the ComparaPanIntegrity group and the ForeignKeyPanMasterTables test case