### PR TITLE
Some of the Compara HC job inputs are too long for the current accu s…

### DIFF
--- a/perl/Bio/EnsEMBL/Healthcheck/Pipeline/RunStandaloneHealthchecksParallel_conf.pm
+++ b/perl/Bio/EnsEMBL/Healthcheck/Pipeline/RunStandaloneHealthchecksParallel_conf.pm
@@ -57,7 +57,8 @@ sub pipeline_create_commands {
     $self->db_cmd('CREATE TABLE job_progress (job_progress_id int(11) NOT NULL AUTO_INCREMENT, job_id int(11) NOT NULL , message TEXT,  PRIMARY KEY (job_progress_id))'),
     $self->db_cmd('ALTER TABLE job_progress ADD INDEX (job_id)'),
     $self->db_cmd('ALTER TABLE job DROP KEY input_id_stacks_analysis'),
-    $self->db_cmd('ALTER TABLE job MODIFY input_id TEXT') ];
+    $self->db_cmd('ALTER TABLE job MODIFY input_id TEXT'),
+    $self->db_cmd('ALTER TABLE accu MODIFY value LONGTEXT')];
 }
 
 sub resource_classes {


### PR DESCRIPTION
…chema definition.
I manually patched the current services databases for Production, vertebrates and non-vertebrates.