### PR TITLE
Update regex for genome components

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/compara/CheckSpeciesSetSizeByMethod.java
+++ b/src/org/ensembl/healthcheck/testcase/compara/CheckSpeciesSetSizeByMethod.java
@@ -35,8 +35,8 @@ public class CheckSpeciesSetSizeByMethod extends AbstractComparaTestCase {
 	protected HashMap<String,String> sizeExceptions = new HashMap<String,String>();
 
 	// Singletons and pairs should follow a certain pattern
-	protected Pattern unaryPattern = Pattern.compile("^([A-Z]\\.?[a-z0-9]{2,3}(\\.?[A-Z])?) ");
-	protected Pattern binaryPattern = Pattern.compile("^([A-Z]\\.?[a-z0-9]{2,3}(\\.?[A-Z])?)-([A-Z]\\.?[a-z0-9]{2,3}(\\.?[A-Z])?) ");
+	protected Pattern unaryPattern = Pattern.compile("^([A-Z]\\.?[a-z0-9]{2,3}(\\.?[A-Z0-9]+)?) ");
+	protected Pattern binaryPattern = Pattern.compile("^([A-Z]\\.?[a-z0-9]{2,3}(\\.?[A-Z0-9]+)?)-([A-Z]\\.?[a-z0-9]{2,3}(\\.?[A-Z0-9]+)?) ");
 
 	public CheckSpeciesSetSizeByMethod() {
 		setTeamResponsible(Team.COMPARA);


### PR DESCRIPTION
_Camelina sativa_ has three genome components named `G1`, `G2` and `G3`, so this regex has had to be updated in order for the HC to pass. Since I don't know exactly the rules for the naming, I have done a broad approach, allowing any combination of capital letters and number.