### PR TITLE
Fix ForeignKeyFuncgenID string comparison

### DIFF
--- a/src/org/ensembl/healthcheck/testcase/variation/ForeignKeyFuncgenId.java
+++ b/src/org/ensembl/healthcheck/testcase/variation/ForeignKeyFuncgenId.java
@@ -71,7 +71,7 @@ public class ForeignKeyFuncgenId extends MultiDatabaseTestCase {
             if (!variationName.matches("master.*")) {
                 try {
                     // Only for human and mouse
-                    if (dbvar.getSpecies() == DatabaseRegistryEntry.HOMO_SAPIENS || dbvar.getSpecies() == DatabaseRegistryEntry.MUS_MUSCULUS) {
+                    if (dbvar.getSpecies().equals(DatabaseRegistryEntry.HOMO_SAPIENS) || dbvar.getSpecies().equals(DatabaseRegistryEntry.MUS_MUSCULUS)) {
                         String funcgenName = variationName.replaceAll("variation", "funcgen");
 
                         DatabaseRegistryEntry dbrfuncgen = allDBR.getByExactName(funcgenName);


### PR DESCRIPTION
This healthcheck is still being run as the replacement DataCheck ForeignKeyMultiDB.pm
does not yet include the check on motif_feature_variation due to speed.

This fix is to make it run for mouse and human.